### PR TITLE
fix(masked-input): set flex width to fix padding

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformbuilders/react-native-elements",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Platform Builders Shared Components Library For React Native",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/TextInput/MaskedTextInput/styles.ts
+++ b/src/components/TextInput/MaskedTextInput/styles.ts
@@ -13,5 +13,5 @@ export const TextInput = styled(Input).attrs((props: Props) => ({
     ? props.placeholderTextColor
     : '#72727260',
 }))`
-  max-width: 100%;
+  flex: 1;
 `;

--- a/src/components/TextInput/styles.ts
+++ b/src/components/TextInput/styles.ts
@@ -132,9 +132,7 @@ export const InputBorderedAreaWrapper = styled.View`
   width: 100%;
 `;
 
-export const InputBorderedColumnWrapper = styled.View<
-  InputBorderedColumnWrapperProps
->`
+export const InputBorderedColumnWrapper = styled.View<InputBorderedColumnWrapperProps>`
   flex-direction: column;
   padding: 0 ${minimumSpacing};
   width: ${({ hasLeftIcon }: InputBorderedColumnWrapperProps) =>


### PR DESCRIPTION
## O que foi feito? 📝

Alterando de `width: 100%` para `flex: 1` pois em casos que tenham `padding` na lateral estava ficando "escondido" parte do texto

## Tipo de mudança 🏗

- [ ] Nova feature (mudança non-breaking que adiciona uma funcionalidade)
- [x] Bug fix (mudança non-breaking que conserta um problema)
- [ ] Refactor (mudança non-breaking que melhora o código ou débito técnico)
- [ ] Chore (nenhuma das anteriores, como upgrade de libs)
- [ ] Breaking change 🚨

## Checklist 🧐

<!-- mobile -->

- [x] Testado no iOS
- [x] Testado no Android
