### PR TITLE
create variant invert

### DIFF
--- a/src/components/Button/styles.ts
+++ b/src/components/Button/styles.ts
@@ -62,6 +62,8 @@ const getBackgroundColor = (props: ButtonWrapperProps): string => {
       return warningMain(props);
     case 'danger':
       return dangerMain(props);
+    case 'invert':
+      return brandPrimaryContrast(props);
     default:
       return brandPrimary(props);
   }
@@ -94,6 +96,8 @@ const getTextColor = (props: TextButtonProps): string => {
       return infoContrast(props);
     case 'warning':
       return warningContrast(props);
+    case 'invert':
+      return brandPrimary(props);
     default:
       return brandPrimaryContrast(props);
   }

--- a/src/types/theme_types/Variants.ts
+++ b/src/types/theme_types/Variants.ts
@@ -5,7 +5,8 @@ export type ButtonVariants =
   | 'accent'
   | 'danger'
   | 'warning'
-  | 'info';
+  | 'info'
+  | 'invert';
 
 export type TypographyVariants =
   | 'min'


### PR DESCRIPTION
## O que foi feito? 📝

Criado a variant invert, nessa variant é usado a cor contrast da brand contrast como background e o texto usa a cor brand primary

## Está de acordo com os critérios de aceite da estória? ✅

- [ ] Resolve todos os critérios de aceite
- [ ] Resolve partes do critério de aceite
- [ ] Não resolve nenhum critério de aceite

## Screenshots ou GIFs 📸


<img width="357" alt="Captura de Tela 2021-10-14 às 17 56 50" src="https://user-images.githubusercontent.com/6132299/137394423-8fd793f6-19f6-49c2-8f5d-8d3ce8fe1318.png">

## Tipo de mudança 🏗

- [x] Nova feature (mudança non-breaking que adiciona uma funcionalidade)
- [ ] Bug fix (mudança non-breaking que conserta um problema)
- [ ] Refactor (mudança non-breaking que melhora o código ou débito técnico)
- [ ] Chore (nenhuma das anteriores, como upgrade de libs)
- [ ] Breaking change 🚨

## Checklist 🧐

<!-- mobile -->

- [x] Testado no iOS
- [x] Testado no Android
<!-- web -->
- [ ] Testado no Chrome
- [ ] Testado no Safari
- [ ] Testado no Firefox
- [ ] Testado no Edge
- [ ] Não gerou alerta ou erro no console
