### PR TITLE
fix: deprecated ViewPropTypes in PinInput

### DIFF
--- a/src/components/PinInput/lib/react-native-smooth-pincode-input/SmoothPinCodeInput.js
+++ b/src/components/PinInput/lib/react-native-smooth-pincode-input/SmoothPinCodeInput.js
@@ -1,13 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import {
-  I18nManager,
-  StyleSheet,
-  Text,
-  TextInput,
-  View,
-  ViewPropTypes,
-} from 'react-native';
+import { I18nManager, StyleSheet, Text, TextInput, View } from 'react-native';
 import * as Animatable from 'react-native-animatable';
 const styles = StyleSheet.create({
   containerDefault: {},
@@ -287,12 +280,12 @@ SmoothPinCodeInput.propTypes = {
   password: PropTypes.bool,
   autoFocus: PropTypes.bool,
   restrictToNumbers: PropTypes.bool,
-  containerStyle: ViewPropTypes.style,
-  cellStyle: ViewPropTypes.style,
-  cellStyleFocused: ViewPropTypes.style,
-  cellStyleFilled: ViewPropTypes.style,
-  textStyle: Text.propTypes.style,
-  textStyleFocused: Text.propTypes.style,
+  containerStyle: PropTypes.style,
+  cellStyle: PropTypes.style,
+  cellStyleFocused: PropTypes.style,
+  cellStyleFilled: PropTypes.style,
+  textStyle: PropTypes.style,
+  textStyleFocused: PropTypes.style,
   animated: PropTypes.bool,
   animationFocused: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   onFulfill: PropTypes.func,


### PR DESCRIPTION
## O que foi feito? 📝

- Mudança na validação da `PropTypes`.
`ViewPropTypes` ficou deprecated e para que possamos conseguir atualizar o template para novas versões do react-native esse ajuste é necessário.

cc: @meycon1 

## Screenshots do teste 📸

![Captura de Tela 2022-09-23 às 15 34 08](https://user-images.githubusercontent.com/84453168/192035122-a3f7a19b-db36-4fea-b596-4cb6c31fb853.png)

## Tipo de mudança 🏗

- [ ] Nova feature (mudança non-breaking que adiciona uma funcionalidade)
- [ ] Bug fix (mudança non-breaking que conserta um problema)
- [x] Refactor (mudança non-breaking que melhora o código ou débito técnico)
- [ ] Chore (nenhuma das anteriores, como upgrade de libs)
- [ ] Breaking change 🚨

## Checklist 🧐

- [ ] Testado no iOS
- [x] Testado no Android
