### PR TITLE
fix(input-error): adding rootStyle and errorStyle to TextInput

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformbuilders/fluid-react-native",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "private": false,
   "description": "Builders React Native for Fluid Design System",
   "keywords": [

--- a/src/components/FormError/index.tsx
+++ b/src/components/FormError/index.tsx
@@ -1,4 +1,5 @@
 import React, { FC } from 'react';
+import { StyleProp, TextStyle } from 'react-native';
 import { ErrorText } from './styles';
 
 const warnBoolean = (): void =>
@@ -13,6 +14,7 @@ type Props = {
   error?: string | string[] | boolean;
   id?: string;
   accessibility?: string;
+  style?: StyleProp<TextStyle>;
 };
 
 const FormError: FC<Props> = ({

--- a/src/components/SearchInput/__tests__/__snapshots__/Search.spec.tsx.snap
+++ b/src/components/SearchInput/__tests__/__snapshots__/Search.spec.tsx.snap
@@ -20,202 +20,211 @@ exports[`<Search /> should render search 1`] = `
   }
 >
   <View
-    multiline={false}
     style={
       Array [
-        Object {
-          "justifyContent": "flex-start",
-          "paddingTop": 0,
-          "position": "relative",
-        },
-        Object {
-          "height": "90%",
-          "paddingBottom": 0,
-          "paddingLeft": 0,
-          "paddingRight": 0,
-          "paddingTop": 0,
-          "width": "100%",
-        },
+        Object {},
+        Object {},
       ]
     }
   >
     <View
-      borderedRadius={0}
-      error={false}
-      showBorderErrored={true}
+      multiline={false}
       style={
         Array [
           Object {
-            "borderColor": "black",
-            "borderStyle": "solid",
-            "borderWidth": 0,
+            "justifyContent": "flex-start",
+            "paddingTop": 0,
+            "position": "relative",
+          },
+          Object {
+            "height": "90%",
+            "paddingBottom": 0,
+            "paddingLeft": 0,
+            "paddingRight": 0,
+            "paddingTop": 0,
+            "width": "100%",
           },
         ]
       }
     >
-      <Text
-        accessibilityLabel="Erro "
-        collapsable={false}
-        contrast={false}
-        nativeID="animatedComponent"
-        status="default"
-        style={
-          Array [
-            Object {
-              "color": "#000000",
-              "fontSize": 15,
-              "lineHeight": 18,
-              "position": "absolute",
-              "top": 8,
-            },
-            Object {
-              "fontSize": 18,
-              "top": 8,
-            },
-          ]
-        }
-        testID="error_test"
-        variant="md"
-      />
       <View
-        multiline={false}
-        rightIcon={false}
+        borderedRadius={0}
+        error={false}
+        showBorderErrored={true}
         style={
           Array [
             Object {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "justifyContent": "center",
-              "maxWidth": "100%",
-              "overflow": "hidden",
-              "paddingLeft": 4,
-              "paddingRight": 4,
-              "paddingTop": 4,
+              "borderColor": "black",
+              "borderStyle": "solid",
+              "borderWidth": 0,
             },
           ]
         }
       >
-        <TextInput
-          accessibility=""
-          accessibilityLabel=""
-          allowFontScaling={false}
-          autoCapitalize="none"
-          autoCompleteType="off"
-          autoCorrect={false}
-          centered={false}
+        <Text
+          accessibilityLabel="Erro "
+          collapsable={false}
           contrast={false}
-          id="test"
-          inputRef="$text"
-          isPlaceholder={true}
-          keyboardType="default"
-          large={false}
-          multiline={false}
-          onBlur={[Function]}
-          onChangeText={[Function]}
-          onFocus={[Function]}
-          onSubmitEditing={[Function]}
-          placeholder=""
-          placeholderTextColor="#72727260"
+          nativeID="animatedComponent"
           status="default"
           style={
             Array [
               Object {
-                "borderWidth": 0,
                 "color": "#000000",
-                "flexBasis": 0,
-                "flexGrow": 1,
-                "flexShrink": 1,
                 "fontSize": 15,
-                "marginTop": 0,
-                "minHeight": 37.714285714285715,
-                "paddingBottom": 0,
-                "paddingLeft": 0,
-                "paddingRight": 0,
-                "paddingTop": 0,
-                "width": "100%",
+                "lineHeight": 18,
+                "position": "absolute",
+                "top": 8,
               },
-              Object {},
+              Object {
+                "fontSize": 18,
+                "top": 8,
+              },
             ]
           }
-          testID="test"
-          textAlign="left"
-          type="no-mask"
-          underlineColorAndroid="transparent"
-          value=""
+          testID="error_test"
           variant="md"
-          withBottomline={true}
         />
         <View
-          collapsable={false}
-          nativeID="animatedComponent"
-          style={Object {}}
+          multiline={false}
+          rightIcon={false}
+          style={
+            Array [
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "justifyContent": "center",
+                "maxWidth": "100%",
+                "overflow": "hidden",
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
+              },
+            ]
+          }
         >
-          <View
-            accessibilityLabel="icon_"
-            accessibilityState={
-              Object {
-                "disabled": false,
-              }
-            }
-            accessible={true}
-            collapsable={false}
-            focusable={true}
-            hitSlop={Object {}}
-            nativeID="animatedComponent"
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
+          <TextInput
+            accessibility=""
+            accessibilityLabel=""
+            allowFontScaling={false}
+            autoCapitalize="none"
+            autoCompleteType="off"
+            autoCorrect={false}
+            centered={false}
+            contrast={false}
+            id="test"
+            inputRef="$text"
+            isPlaceholder={true}
+            keyboardType="default"
+            large={false}
+            multiline={false}
+            onBlur={[Function]}
+            onChangeText={[Function]}
+            onFocus={[Function]}
+            onSubmitEditing={[Function]}
+            placeholder=""
+            placeholderTextColor="#72727260"
+            status="default"
             style={
-              Object {
-                "opacity": 1,
-              }
+              Array [
+                Object {
+                  "borderWidth": 0,
+                  "color": "#000000",
+                  "flexBasis": 0,
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                  "fontSize": 15,
+                  "marginTop": 0,
+                  "minHeight": 37.714285714285715,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "width": "100%",
+                },
+                Object {},
+              ]
             }
-            testID="id_magnify"
+            testID="test"
+            textAlign="left"
+            type="no-mask"
+            underlineColorAndroid="transparent"
+            value=""
+            variant="md"
+            withBottomline={true}
+          />
+          <View
+            collapsable={false}
+            nativeID="animatedComponent"
+            style={Object {}}
           >
-            <View>
-              <Text
-                allowFontScaling={false}
-                style={
-                  Array [
-                    Object {
-                      "color": "function (_ref) {
+            <View
+              accessibilityLabel="icon_"
+              accessibilityState={
+                Object {
+                  "disabled": false,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              hitSlop={Object {}}
+              nativeID="animatedComponent"
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                Object {
+                  "opacity": 1,
+                }
+              }
+              testID="id_magnify"
+            >
+              <View>
+                <Text
+                  allowFontScaling={false}
+                  style={
+                    Array [
+                      Object {
+                        "color": "function (_ref) {
     var theme = _ref.theme;
     return lodash_1(theme, themeProp);
   }",
-                      "fontSize": 40.85714285714286,
-                    },
-                    undefined,
-                    Object {
-                      "fontFamily": "Material Design Icons",
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                󰍉
-              </Text>
+                        "fontSize": 40.85714285714286,
+                      },
+                      undefined,
+                      Object {
+                        "fontFamily": "Material Design Icons",
+                        "fontStyle": "normal",
+                        "fontWeight": "normal",
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  󰍉
+                </Text>
+              </View>
             </View>
           </View>
         </View>
+        <View
+          contrast={false}
+          status="default"
+          style={
+            Array [
+              Object {
+                "backgroundColor": "#000000",
+                "height": 0.5,
+              },
+            ]
+          }
+        />
       </View>
-      <View
-        contrast={false}
-        status="default"
-        style={
-          Array [
-            Object {
-              "backgroundColor": "#000000",
-              "height": 0.5,
-            },
-          ]
-        }
-      />
     </View>
   </View>
 </View>
@@ -241,196 +250,205 @@ exports[`<Search /> should render search with auto focus 1`] = `
   }
 >
   <View
-    multiline={false}
     style={
       Array [
-        Object {
-          "justifyContent": "flex-start",
-          "paddingTop": 0,
-          "position": "relative",
-        },
-        Object {
-          "height": "90%",
-          "paddingBottom": 0,
-          "paddingLeft": 0,
-          "paddingRight": 0,
-          "paddingTop": 0,
-          "width": "100%",
-        },
+        Object {},
+        Object {},
       ]
     }
   >
     <View
-      borderedRadius={0}
-      error={false}
-      showBorderErrored={true}
+      multiline={false}
       style={
         Array [
           Object {
-            "borderColor": "black",
-            "borderStyle": "solid",
-            "borderWidth": 0,
+            "justifyContent": "flex-start",
+            "paddingTop": 0,
+            "position": "relative",
+          },
+          Object {
+            "height": "90%",
+            "paddingBottom": 0,
+            "paddingLeft": 0,
+            "paddingRight": 0,
+            "paddingTop": 0,
+            "width": "100%",
           },
         ]
       }
     >
-      <Text
-        accessibilityLabel="Erro "
-        contrast={false}
-        status="default"
-        style={
-          Array [
-            Object {
-              "color": "#000000",
-              "fontSize": 13,
-              "lineHeight": 15.6,
-              "position": "absolute",
-              "top": 8,
-            },
-            Object {
-              "fontSize": 18,
-              "top": 8,
-            },
-          ]
-        }
-        testID="error_test"
-        variant="xs"
-      />
       <View
-        multiline={false}
-        rightIcon={false}
+        borderedRadius={0}
+        error={false}
+        showBorderErrored={true}
         style={
           Array [
             Object {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "justifyContent": "center",
-              "maxWidth": "100%",
-              "overflow": "hidden",
-              "paddingLeft": 4,
-              "paddingRight": 4,
-              "paddingTop": 4,
+              "borderColor": "black",
+              "borderStyle": "solid",
+              "borderWidth": 0,
             },
           ]
         }
       >
-        <TextInput
-          accessibility=""
-          accessibilityLabel=""
-          allowFontScaling={false}
-          autoCapitalize="none"
-          autoCompleteType="off"
-          autoCorrect={false}
-          centered={false}
+        <Text
+          accessibilityLabel="Erro "
           contrast={false}
-          id="test"
-          inputRef="$text"
-          isPlaceholder={false}
-          keyboardType="default"
-          large={false}
-          multiline={false}
-          onBlur={[Function]}
-          onChangeText={[Function]}
-          onFocus={[Function]}
-          onSubmitEditing={[Function]}
-          placeholder="Pesquise aqui"
-          placeholderTextColor="#72727260"
           status="default"
           style={
             Array [
               Object {
-                "borderWidth": 0,
                 "color": "#000000",
-                "flexBasis": 0,
-                "flexGrow": 1,
-                "flexShrink": 1,
-                "fontSize": 15,
-                "marginTop": 0,
-                "minHeight": 37.714285714285715,
-                "paddingBottom": 0,
-                "paddingLeft": 0,
-                "paddingRight": 0,
-                "paddingTop": 0,
-                "width": "100%",
+                "fontSize": 13,
+                "lineHeight": 15.6,
+                "position": "absolute",
+                "top": 8,
               },
-              Object {},
+              Object {
+                "fontSize": 18,
+                "top": 8,
+              },
             ]
           }
-          testID="test"
-          textAlign="left"
-          type="no-mask"
-          underlineColorAndroid="transparent"
-          value=""
-          variant="md"
-          withBottomline={true}
+          testID="error_test"
+          variant="xs"
         />
         <View
-          style={Object {}}
+          multiline={false}
+          rightIcon={false}
+          style={
+            Array [
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "justifyContent": "center",
+                "maxWidth": "100%",
+                "overflow": "hidden",
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
+              },
+            ]
+          }
         >
-          <View
-            accessibilityLabel="icon_"
-            accessibilityState={
-              Object {
-                "disabled": false,
-              }
-            }
-            accessible={true}
-            focusable={true}
-            hitSlop={Object {}}
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
+          <TextInput
+            accessibility=""
+            accessibilityLabel=""
+            allowFontScaling={false}
+            autoCapitalize="none"
+            autoCompleteType="off"
+            autoCorrect={false}
+            centered={false}
+            contrast={false}
+            id="test"
+            inputRef="$text"
+            isPlaceholder={false}
+            keyboardType="default"
+            large={false}
+            multiline={false}
+            onBlur={[Function]}
+            onChangeText={[Function]}
+            onFocus={[Function]}
+            onSubmitEditing={[Function]}
+            placeholder="Pesquise aqui"
+            placeholderTextColor="#72727260"
+            status="default"
             style={
-              Object {
-                "opacity": 1,
-              }
+              Array [
+                Object {
+                  "borderWidth": 0,
+                  "color": "#000000",
+                  "flexBasis": 0,
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                  "fontSize": 15,
+                  "marginTop": 0,
+                  "minHeight": 37.714285714285715,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "width": "100%",
+                },
+                Object {},
+              ]
             }
-            testID="id_magnify"
+            testID="test"
+            textAlign="left"
+            type="no-mask"
+            underlineColorAndroid="transparent"
+            value=""
+            variant="md"
+            withBottomline={true}
+          />
+          <View
+            style={Object {}}
           >
-            <View>
-              <Text
-                allowFontScaling={false}
-                style={
-                  Array [
-                    Object {
-                      "color": "function (_ref) {
+            <View
+              accessibilityLabel="icon_"
+              accessibilityState={
+                Object {
+                  "disabled": false,
+                }
+              }
+              accessible={true}
+              focusable={true}
+              hitSlop={Object {}}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                Object {
+                  "opacity": 1,
+                }
+              }
+              testID="id_magnify"
+            >
+              <View>
+                <Text
+                  allowFontScaling={false}
+                  style={
+                    Array [
+                      Object {
+                        "color": "function (_ref) {
     var theme = _ref.theme;
     return lodash_1(theme, themeProp);
   }",
-                      "fontSize": 40.85714285714286,
-                    },
-                    undefined,
-                    Object {
-                      "fontFamily": "Material Design Icons",
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                󰍉
-              </Text>
+                        "fontSize": 40.85714285714286,
+                      },
+                      undefined,
+                      Object {
+                        "fontFamily": "Material Design Icons",
+                        "fontStyle": "normal",
+                        "fontWeight": "normal",
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  󰍉
+                </Text>
+              </View>
             </View>
           </View>
         </View>
+        <View
+          contrast={false}
+          status="default"
+          style={
+            Array [
+              Object {
+                "backgroundColor": "#000000",
+                "height": 0.5,
+              },
+            ]
+          }
+        />
       </View>
-      <View
-        contrast={false}
-        status="default"
-        style={
-          Array [
-            Object {
-              "backgroundColor": "#000000",
-              "height": 0.5,
-            },
-          ]
-        }
-      />
     </View>
   </View>
 </View>
@@ -459,196 +477,205 @@ exports[`<Search /> should render search with custom container style 1`] = `
   }
 >
   <View
-    multiline={false}
     style={
       Array [
-        Object {
-          "justifyContent": "flex-start",
-          "paddingTop": 0,
-          "position": "relative",
-        },
-        Object {
-          "height": "90%",
-          "paddingBottom": 0,
-          "paddingLeft": 0,
-          "paddingRight": 0,
-          "paddingTop": 0,
-          "width": "100%",
-        },
+        Object {},
+        Object {},
       ]
     }
   >
     <View
-      borderedRadius={0}
-      error={false}
-      showBorderErrored={true}
+      multiline={false}
       style={
         Array [
           Object {
-            "borderColor": "black",
-            "borderStyle": "solid",
-            "borderWidth": 0,
+            "justifyContent": "flex-start",
+            "paddingTop": 0,
+            "position": "relative",
+          },
+          Object {
+            "height": "90%",
+            "paddingBottom": 0,
+            "paddingLeft": 0,
+            "paddingRight": 0,
+            "paddingTop": 0,
+            "width": "100%",
           },
         ]
       }
     >
-      <Text
-        accessibilityLabel="Erro "
-        contrast={false}
-        status="default"
-        style={
-          Array [
-            Object {
-              "color": "#000000",
-              "fontSize": 13,
-              "lineHeight": 15.6,
-              "position": "absolute",
-              "top": 8,
-            },
-            Object {
-              "fontSize": 18,
-              "top": 8,
-            },
-          ]
-        }
-        testID="error_test"
-        variant="xs"
-      />
       <View
-        multiline={false}
-        rightIcon={false}
+        borderedRadius={0}
+        error={false}
+        showBorderErrored={true}
         style={
           Array [
             Object {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "justifyContent": "center",
-              "maxWidth": "100%",
-              "overflow": "hidden",
-              "paddingLeft": 4,
-              "paddingRight": 4,
-              "paddingTop": 4,
+              "borderColor": "black",
+              "borderStyle": "solid",
+              "borderWidth": 0,
             },
           ]
         }
       >
-        <TextInput
-          accessibility=""
-          accessibilityLabel=""
-          allowFontScaling={false}
-          autoCapitalize="none"
-          autoCompleteType="off"
-          autoCorrect={false}
-          centered={false}
+        <Text
+          accessibilityLabel="Erro "
           contrast={false}
-          id="test"
-          inputRef="$text"
-          isPlaceholder={false}
-          keyboardType="default"
-          large={false}
-          multiline={false}
-          onBlur={[Function]}
-          onChangeText={[Function]}
-          onFocus={[Function]}
-          onSubmitEditing={[Function]}
-          placeholder="Pesquise aqui"
-          placeholderTextColor="#72727260"
           status="default"
           style={
             Array [
               Object {
-                "borderWidth": 0,
                 "color": "#000000",
-                "flexBasis": 0,
-                "flexGrow": 1,
-                "flexShrink": 1,
-                "fontSize": 15,
-                "marginTop": 0,
-                "minHeight": 37.714285714285715,
-                "paddingBottom": 0,
-                "paddingLeft": 0,
-                "paddingRight": 0,
-                "paddingTop": 0,
-                "width": "100%",
+                "fontSize": 13,
+                "lineHeight": 15.6,
+                "position": "absolute",
+                "top": 8,
               },
-              Object {},
+              Object {
+                "fontSize": 18,
+                "top": 8,
+              },
             ]
           }
-          testID="test"
-          textAlign="left"
-          type="no-mask"
-          underlineColorAndroid="transparent"
-          value=""
-          variant="md"
-          withBottomline={true}
+          testID="error_test"
+          variant="xs"
         />
         <View
-          style={Object {}}
+          multiline={false}
+          rightIcon={false}
+          style={
+            Array [
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "justifyContent": "center",
+                "maxWidth": "100%",
+                "overflow": "hidden",
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
+              },
+            ]
+          }
         >
-          <View
-            accessibilityLabel="icon_"
-            accessibilityState={
-              Object {
-                "disabled": false,
-              }
-            }
-            accessible={true}
-            focusable={true}
-            hitSlop={Object {}}
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
+          <TextInput
+            accessibility=""
+            accessibilityLabel=""
+            allowFontScaling={false}
+            autoCapitalize="none"
+            autoCompleteType="off"
+            autoCorrect={false}
+            centered={false}
+            contrast={false}
+            id="test"
+            inputRef="$text"
+            isPlaceholder={false}
+            keyboardType="default"
+            large={false}
+            multiline={false}
+            onBlur={[Function]}
+            onChangeText={[Function]}
+            onFocus={[Function]}
+            onSubmitEditing={[Function]}
+            placeholder="Pesquise aqui"
+            placeholderTextColor="#72727260"
+            status="default"
             style={
-              Object {
-                "opacity": 1,
-              }
+              Array [
+                Object {
+                  "borderWidth": 0,
+                  "color": "#000000",
+                  "flexBasis": 0,
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                  "fontSize": 15,
+                  "marginTop": 0,
+                  "minHeight": 37.714285714285715,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "width": "100%",
+                },
+                Object {},
+              ]
             }
-            testID="id_magnify"
+            testID="test"
+            textAlign="left"
+            type="no-mask"
+            underlineColorAndroid="transparent"
+            value=""
+            variant="md"
+            withBottomline={true}
+          />
+          <View
+            style={Object {}}
           >
-            <View>
-              <Text
-                allowFontScaling={false}
-                style={
-                  Array [
-                    Object {
-                      "color": "function (_ref) {
+            <View
+              accessibilityLabel="icon_"
+              accessibilityState={
+                Object {
+                  "disabled": false,
+                }
+              }
+              accessible={true}
+              focusable={true}
+              hitSlop={Object {}}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                Object {
+                  "opacity": 1,
+                }
+              }
+              testID="id_magnify"
+            >
+              <View>
+                <Text
+                  allowFontScaling={false}
+                  style={
+                    Array [
+                      Object {
+                        "color": "function (_ref) {
     var theme = _ref.theme;
     return lodash_1(theme, themeProp);
   }",
-                      "fontSize": 40.85714285714286,
-                    },
-                    undefined,
-                    Object {
-                      "fontFamily": "Material Design Icons",
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                󰍉
-              </Text>
+                        "fontSize": 40.85714285714286,
+                      },
+                      undefined,
+                      Object {
+                        "fontFamily": "Material Design Icons",
+                        "fontStyle": "normal",
+                        "fontWeight": "normal",
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  󰍉
+                </Text>
+              </View>
             </View>
           </View>
         </View>
+        <View
+          contrast={false}
+          status="default"
+          style={
+            Array [
+              Object {
+                "backgroundColor": "#000000",
+                "height": 0.5,
+              },
+            ]
+          }
+        />
       </View>
-      <View
-        contrast={false}
-        status="default"
-        style={
-          Array [
-            Object {
-              "backgroundColor": "#000000",
-              "height": 0.5,
-            },
-          ]
-        }
-      />
     </View>
   </View>
 </View>
@@ -674,193 +701,202 @@ exports[`<Search /> should render search with custom icon color 1`] = `
   }
 >
   <View
-    multiline={false}
     style={
       Array [
-        Object {
-          "justifyContent": "flex-start",
-          "paddingTop": 0,
-          "position": "relative",
-        },
-        Object {
-          "height": "90%",
-          "paddingBottom": 0,
-          "paddingLeft": 0,
-          "paddingRight": 0,
-          "paddingTop": 0,
-          "width": "100%",
-        },
+        Object {},
+        Object {},
       ]
     }
   >
     <View
-      borderedRadius={0}
-      error={false}
-      showBorderErrored={true}
+      multiline={false}
       style={
         Array [
           Object {
-            "borderColor": "black",
-            "borderStyle": "solid",
-            "borderWidth": 0,
+            "justifyContent": "flex-start",
+            "paddingTop": 0,
+            "position": "relative",
+          },
+          Object {
+            "height": "90%",
+            "paddingBottom": 0,
+            "paddingLeft": 0,
+            "paddingRight": 0,
+            "paddingTop": 0,
+            "width": "100%",
           },
         ]
       }
     >
-      <Text
-        accessibilityLabel="Erro "
-        contrast={false}
-        status="default"
-        style={
-          Array [
-            Object {
-              "color": "#000000",
-              "fontSize": 13,
-              "lineHeight": 15.6,
-              "position": "absolute",
-              "top": 8,
-            },
-            Object {
-              "fontSize": 18,
-              "top": 8,
-            },
-          ]
-        }
-        testID="error_test"
-        variant="xs"
-      />
       <View
-        multiline={false}
-        rightIcon={false}
+        borderedRadius={0}
+        error={false}
+        showBorderErrored={true}
         style={
           Array [
             Object {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "justifyContent": "center",
-              "maxWidth": "100%",
-              "overflow": "hidden",
-              "paddingLeft": 4,
-              "paddingRight": 4,
-              "paddingTop": 4,
+              "borderColor": "black",
+              "borderStyle": "solid",
+              "borderWidth": 0,
             },
           ]
         }
       >
-        <TextInput
-          accessibility=""
-          accessibilityLabel=""
-          allowFontScaling={false}
-          autoCapitalize="none"
-          autoCompleteType="off"
-          autoCorrect={false}
-          centered={false}
+        <Text
+          accessibilityLabel="Erro "
           contrast={false}
-          id="test"
-          inputRef="$text"
-          isPlaceholder={false}
-          keyboardType="default"
-          large={false}
-          multiline={false}
-          onBlur={[Function]}
-          onChangeText={[Function]}
-          onFocus={[Function]}
-          onSubmitEditing={[Function]}
-          placeholder="Pesquise aqui"
-          placeholderTextColor="#72727260"
           status="default"
           style={
             Array [
               Object {
-                "borderWidth": 0,
                 "color": "#000000",
-                "flexBasis": 0,
-                "flexGrow": 1,
-                "flexShrink": 1,
-                "fontSize": 15,
-                "marginTop": 0,
-                "minHeight": 37.714285714285715,
-                "paddingBottom": 0,
-                "paddingLeft": 0,
-                "paddingRight": 0,
-                "paddingTop": 0,
-                "width": "100%",
+                "fontSize": 13,
+                "lineHeight": 15.6,
+                "position": "absolute",
+                "top": 8,
               },
-              Object {},
+              Object {
+                "fontSize": 18,
+                "top": 8,
+              },
             ]
           }
-          testID="test"
-          textAlign="left"
-          type="no-mask"
-          underlineColorAndroid="transparent"
-          value=""
-          variant="md"
-          withBottomline={true}
+          testID="error_test"
+          variant="xs"
         />
         <View
-          style={Object {}}
+          multiline={false}
+          rightIcon={false}
+          style={
+            Array [
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "justifyContent": "center",
+                "maxWidth": "100%",
+                "overflow": "hidden",
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
+              },
+            ]
+          }
         >
-          <View
-            accessibilityLabel="icon_"
-            accessibilityState={
-              Object {
-                "disabled": false,
-              }
-            }
-            accessible={true}
-            focusable={true}
-            hitSlop={Object {}}
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
+          <TextInput
+            accessibility=""
+            accessibilityLabel=""
+            allowFontScaling={false}
+            autoCapitalize="none"
+            autoCompleteType="off"
+            autoCorrect={false}
+            centered={false}
+            contrast={false}
+            id="test"
+            inputRef="$text"
+            isPlaceholder={false}
+            keyboardType="default"
+            large={false}
+            multiline={false}
+            onBlur={[Function]}
+            onChangeText={[Function]}
+            onFocus={[Function]}
+            onSubmitEditing={[Function]}
+            placeholder="Pesquise aqui"
+            placeholderTextColor="#72727260"
+            status="default"
             style={
-              Object {
-                "opacity": 1,
-              }
+              Array [
+                Object {
+                  "borderWidth": 0,
+                  "color": "#000000",
+                  "flexBasis": 0,
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                  "fontSize": 15,
+                  "marginTop": 0,
+                  "minHeight": 37.714285714285715,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "width": "100%",
+                },
+                Object {},
+              ]
             }
-            testID="id_magnify"
+            testID="test"
+            textAlign="left"
+            type="no-mask"
+            underlineColorAndroid="transparent"
+            value=""
+            variant="md"
+            withBottomline={true}
+          />
+          <View
+            style={Object {}}
           >
-            <View>
-              <Text
-                allowFontScaling={false}
-                style={
-                  Array [
-                    Object {
-                      "color": "#fff",
-                      "fontSize": 40.85714285714286,
-                    },
-                    undefined,
-                    Object {
-                      "fontFamily": "Material Design Icons",
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
-                    },
-                    Object {},
-                  ]
+            <View
+              accessibilityLabel="icon_"
+              accessibilityState={
+                Object {
+                  "disabled": false,
                 }
-              >
-                󰍉
-              </Text>
+              }
+              accessible={true}
+              focusable={true}
+              hitSlop={Object {}}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                Object {
+                  "opacity": 1,
+                }
+              }
+              testID="id_magnify"
+            >
+              <View>
+                <Text
+                  allowFontScaling={false}
+                  style={
+                    Array [
+                      Object {
+                        "color": "#fff",
+                        "fontSize": 40.85714285714286,
+                      },
+                      undefined,
+                      Object {
+                        "fontFamily": "Material Design Icons",
+                        "fontStyle": "normal",
+                        "fontWeight": "normal",
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  󰍉
+                </Text>
+              </View>
             </View>
           </View>
         </View>
+        <View
+          contrast={false}
+          status="default"
+          style={
+            Array [
+              Object {
+                "backgroundColor": "#000000",
+                "height": 0.5,
+              },
+            ]
+          }
+        />
       </View>
-      <View
-        contrast={false}
-        status="default"
-        style={
-          Array [
-            Object {
-              "backgroundColor": "#000000",
-              "height": 0.5,
-            },
-          ]
-        }
-      />
     </View>
   </View>
 </View>
@@ -886,205 +922,214 @@ exports[`<Search /> should render search with custom input style 1`] = `
   }
 >
   <View
-    multiline={false}
     style={
       Array [
-        Object {
-          "justifyContent": "flex-start",
-          "paddingTop": 0,
-          "position": "relative",
-        },
-        Object {
-          "height": "90%",
-          "paddingBottom": 0,
-          "paddingLeft": 0,
-          "paddingRight": 0,
-          "paddingTop": 0,
-          "width": "100%",
-        },
-        Object {
-          "backgroundColor": "#654654",
-        },
+        Object {},
+        Object {},
       ]
     }
   >
     <View
-      borderedRadius={0}
-      error={false}
-      showBorderErrored={true}
+      multiline={false}
       style={
         Array [
           Object {
-            "borderColor": "black",
-            "borderStyle": "solid",
-            "borderWidth": 0,
+            "justifyContent": "flex-start",
+            "paddingTop": 0,
+            "position": "relative",
+          },
+          Object {
+            "height": "90%",
+            "paddingBottom": 0,
+            "paddingLeft": 0,
+            "paddingRight": 0,
+            "paddingTop": 0,
+            "width": "100%",
+          },
+          Object {
+            "backgroundColor": "#654654",
           },
         ]
       }
     >
-      <Text
-        accessibilityLabel="Erro "
-        collapsable={false}
-        contrast={false}
-        nativeID="animatedComponent"
-        status="default"
-        style={
-          Array [
-            Object {
-              "color": "#000000",
-              "fontSize": 15,
-              "lineHeight": 18,
-              "position": "absolute",
-              "top": 8,
-            },
-            Object {
-              "fontSize": 18,
-              "top": 8,
-            },
-          ]
-        }
-        testID="error_test"
-        variant="md"
-      />
       <View
-        multiline={false}
-        rightIcon={false}
+        borderedRadius={0}
+        error={false}
+        showBorderErrored={true}
         style={
           Array [
             Object {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "justifyContent": "center",
-              "maxWidth": "100%",
-              "overflow": "hidden",
-              "paddingLeft": 4,
-              "paddingRight": 4,
-              "paddingTop": 4,
+              "borderColor": "black",
+              "borderStyle": "solid",
+              "borderWidth": 0,
             },
           ]
         }
       >
-        <TextInput
-          accessibility=""
-          accessibilityLabel=""
-          allowFontScaling={false}
-          autoCapitalize="none"
-          autoCompleteType="off"
-          autoCorrect={false}
-          centered={false}
+        <Text
+          accessibilityLabel="Erro "
+          collapsable={false}
           contrast={false}
-          id="test"
-          inputRef="$text"
-          isPlaceholder={true}
-          keyboardType="default"
-          large={false}
-          multiline={false}
-          onBlur={[Function]}
-          onChangeText={[Function]}
-          onFocus={[Function]}
-          onSubmitEditing={[Function]}
-          placeholder=""
-          placeholderTextColor="#72727260"
+          nativeID="animatedComponent"
           status="default"
           style={
             Array [
               Object {
-                "borderWidth": 0,
                 "color": "#000000",
-                "flexBasis": 0,
-                "flexGrow": 1,
-                "flexShrink": 1,
                 "fontSize": 15,
-                "marginTop": 0,
-                "minHeight": 37.714285714285715,
-                "paddingBottom": 0,
-                "paddingLeft": 0,
-                "paddingRight": 0,
-                "paddingTop": 0,
-                "width": "100%",
+                "lineHeight": 18,
+                "position": "absolute",
+                "top": 8,
               },
-              Object {},
+              Object {
+                "fontSize": 18,
+                "top": 8,
+              },
             ]
           }
-          testID="test"
-          textAlign="left"
-          type="no-mask"
-          underlineColorAndroid="transparent"
-          value=""
+          testID="error_test"
           variant="md"
-          withBottomline={true}
         />
         <View
-          collapsable={false}
-          nativeID="animatedComponent"
-          style={Object {}}
+          multiline={false}
+          rightIcon={false}
+          style={
+            Array [
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "justifyContent": "center",
+                "maxWidth": "100%",
+                "overflow": "hidden",
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
+              },
+            ]
+          }
         >
-          <View
-            accessibilityLabel="icon_"
-            accessibilityState={
-              Object {
-                "disabled": false,
-              }
-            }
-            accessible={true}
-            collapsable={false}
-            focusable={true}
-            hitSlop={Object {}}
-            nativeID="animatedComponent"
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
+          <TextInput
+            accessibility=""
+            accessibilityLabel=""
+            allowFontScaling={false}
+            autoCapitalize="none"
+            autoCompleteType="off"
+            autoCorrect={false}
+            centered={false}
+            contrast={false}
+            id="test"
+            inputRef="$text"
+            isPlaceholder={true}
+            keyboardType="default"
+            large={false}
+            multiline={false}
+            onBlur={[Function]}
+            onChangeText={[Function]}
+            onFocus={[Function]}
+            onSubmitEditing={[Function]}
+            placeholder=""
+            placeholderTextColor="#72727260"
+            status="default"
             style={
-              Object {
-                "opacity": 1,
-              }
+              Array [
+                Object {
+                  "borderWidth": 0,
+                  "color": "#000000",
+                  "flexBasis": 0,
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                  "fontSize": 15,
+                  "marginTop": 0,
+                  "minHeight": 37.714285714285715,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "width": "100%",
+                },
+                Object {},
+              ]
             }
-            testID="id_magnify"
+            testID="test"
+            textAlign="left"
+            type="no-mask"
+            underlineColorAndroid="transparent"
+            value=""
+            variant="md"
+            withBottomline={true}
+          />
+          <View
+            collapsable={false}
+            nativeID="animatedComponent"
+            style={Object {}}
           >
-            <View>
-              <Text
-                allowFontScaling={false}
-                style={
-                  Array [
-                    Object {
-                      "color": "function (_ref) {
+            <View
+              accessibilityLabel="icon_"
+              accessibilityState={
+                Object {
+                  "disabled": false,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              hitSlop={Object {}}
+              nativeID="animatedComponent"
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                Object {
+                  "opacity": 1,
+                }
+              }
+              testID="id_magnify"
+            >
+              <View>
+                <Text
+                  allowFontScaling={false}
+                  style={
+                    Array [
+                      Object {
+                        "color": "function (_ref) {
     var theme = _ref.theme;
     return lodash_1(theme, themeProp);
   }",
-                      "fontSize": 40.85714285714286,
-                    },
-                    undefined,
-                    Object {
-                      "fontFamily": "Material Design Icons",
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                󰍉
-              </Text>
+                        "fontSize": 40.85714285714286,
+                      },
+                      undefined,
+                      Object {
+                        "fontFamily": "Material Design Icons",
+                        "fontStyle": "normal",
+                        "fontWeight": "normal",
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  󰍉
+                </Text>
+              </View>
             </View>
           </View>
         </View>
+        <View
+          contrast={false}
+          status="default"
+          style={
+            Array [
+              Object {
+                "backgroundColor": "#000000",
+                "height": 0.5,
+              },
+            ]
+          }
+        />
       </View>
-      <View
-        contrast={false}
-        status="default"
-        style={
-          Array [
-            Object {
-              "backgroundColor": "#000000",
-              "height": 0.5,
-            },
-          ]
-        }
-      />
     </View>
   </View>
 </View>
@@ -1110,202 +1155,211 @@ exports[`<Search /> should render search with custom placeholder 1`] = `
   }
 >
   <View
-    multiline={false}
     style={
       Array [
-        Object {
-          "justifyContent": "flex-start",
-          "paddingTop": 0,
-          "position": "relative",
-        },
-        Object {
-          "height": "90%",
-          "paddingBottom": 0,
-          "paddingLeft": 0,
-          "paddingRight": 0,
-          "paddingTop": 0,
-          "width": "100%",
-        },
+        Object {},
+        Object {},
       ]
     }
   >
     <View
-      borderedRadius={0}
-      error={false}
-      showBorderErrored={true}
+      multiline={false}
       style={
         Array [
           Object {
-            "borderColor": "black",
-            "borderStyle": "solid",
-            "borderWidth": 0,
+            "justifyContent": "flex-start",
+            "paddingTop": 0,
+            "position": "relative",
+          },
+          Object {
+            "height": "90%",
+            "paddingBottom": 0,
+            "paddingLeft": 0,
+            "paddingRight": 0,
+            "paddingTop": 0,
+            "width": "100%",
           },
         ]
       }
     >
-      <Text
-        accessibilityLabel="Erro "
-        collapsable={false}
-        contrast={false}
-        nativeID="animatedComponent"
-        status="default"
-        style={
-          Array [
-            Object {
-              "color": "#000000",
-              "fontSize": 15,
-              "lineHeight": 18,
-              "position": "absolute",
-              "top": 8,
-            },
-            Object {
-              "fontSize": 18,
-              "top": 8,
-            },
-          ]
-        }
-        testID="error_test"
-        variant="md"
-      />
       <View
-        multiline={false}
-        rightIcon={false}
+        borderedRadius={0}
+        error={false}
+        showBorderErrored={true}
         style={
           Array [
             Object {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "justifyContent": "center",
-              "maxWidth": "100%",
-              "overflow": "hidden",
-              "paddingLeft": 4,
-              "paddingRight": 4,
-              "paddingTop": 4,
+              "borderColor": "black",
+              "borderStyle": "solid",
+              "borderWidth": 0,
             },
           ]
         }
       >
-        <TextInput
-          accessibility=""
-          accessibilityLabel=""
-          allowFontScaling={false}
-          autoCapitalize="none"
-          autoCompleteType="off"
-          autoCorrect={false}
-          centered={false}
+        <Text
+          accessibilityLabel="Erro "
+          collapsable={false}
           contrast={false}
-          id="test"
-          inputRef="$text"
-          isPlaceholder={true}
-          keyboardType="default"
-          large={false}
-          multiline={false}
-          onBlur={[Function]}
-          onChangeText={[Function]}
-          onFocus={[Function]}
-          onSubmitEditing={[Function]}
-          placeholder=""
-          placeholderTextColor="#72727260"
+          nativeID="animatedComponent"
           status="default"
           style={
             Array [
               Object {
-                "borderWidth": 0,
                 "color": "#000000",
-                "flexBasis": 0,
-                "flexGrow": 1,
-                "flexShrink": 1,
                 "fontSize": 15,
-                "marginTop": 0,
-                "minHeight": 37.714285714285715,
-                "paddingBottom": 0,
-                "paddingLeft": 0,
-                "paddingRight": 0,
-                "paddingTop": 0,
-                "width": "100%",
+                "lineHeight": 18,
+                "position": "absolute",
+                "top": 8,
               },
-              Object {},
+              Object {
+                "fontSize": 18,
+                "top": 8,
+              },
             ]
           }
-          testID="test"
-          textAlign="left"
-          type="no-mask"
-          underlineColorAndroid="transparent"
-          value=""
+          testID="error_test"
           variant="md"
-          withBottomline={true}
         />
         <View
-          collapsable={false}
-          nativeID="animatedComponent"
-          style={Object {}}
+          multiline={false}
+          rightIcon={false}
+          style={
+            Array [
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "justifyContent": "center",
+                "maxWidth": "100%",
+                "overflow": "hidden",
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
+              },
+            ]
+          }
         >
-          <View
-            accessibilityLabel="icon_"
-            accessibilityState={
-              Object {
-                "disabled": false,
-              }
-            }
-            accessible={true}
-            collapsable={false}
-            focusable={true}
-            hitSlop={Object {}}
-            nativeID="animatedComponent"
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
+          <TextInput
+            accessibility=""
+            accessibilityLabel=""
+            allowFontScaling={false}
+            autoCapitalize="none"
+            autoCompleteType="off"
+            autoCorrect={false}
+            centered={false}
+            contrast={false}
+            id="test"
+            inputRef="$text"
+            isPlaceholder={true}
+            keyboardType="default"
+            large={false}
+            multiline={false}
+            onBlur={[Function]}
+            onChangeText={[Function]}
+            onFocus={[Function]}
+            onSubmitEditing={[Function]}
+            placeholder=""
+            placeholderTextColor="#72727260"
+            status="default"
             style={
-              Object {
-                "opacity": 1,
-              }
+              Array [
+                Object {
+                  "borderWidth": 0,
+                  "color": "#000000",
+                  "flexBasis": 0,
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                  "fontSize": 15,
+                  "marginTop": 0,
+                  "minHeight": 37.714285714285715,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "width": "100%",
+                },
+                Object {},
+              ]
             }
-            testID="id_magnify"
+            testID="test"
+            textAlign="left"
+            type="no-mask"
+            underlineColorAndroid="transparent"
+            value=""
+            variant="md"
+            withBottomline={true}
+          />
+          <View
+            collapsable={false}
+            nativeID="animatedComponent"
+            style={Object {}}
           >
-            <View>
-              <Text
-                allowFontScaling={false}
-                style={
-                  Array [
-                    Object {
-                      "color": "function (_ref) {
+            <View
+              accessibilityLabel="icon_"
+              accessibilityState={
+                Object {
+                  "disabled": false,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              hitSlop={Object {}}
+              nativeID="animatedComponent"
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                Object {
+                  "opacity": 1,
+                }
+              }
+              testID="id_magnify"
+            >
+              <View>
+                <Text
+                  allowFontScaling={false}
+                  style={
+                    Array [
+                      Object {
+                        "color": "function (_ref) {
     var theme = _ref.theme;
     return lodash_1(theme, themeProp);
   }",
-                      "fontSize": 40.85714285714286,
-                    },
-                    undefined,
-                    Object {
-                      "fontFamily": "Material Design Icons",
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                󰍉
-              </Text>
+                        "fontSize": 40.85714285714286,
+                      },
+                      undefined,
+                      Object {
+                        "fontFamily": "Material Design Icons",
+                        "fontStyle": "normal",
+                        "fontWeight": "normal",
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  󰍉
+                </Text>
+              </View>
             </View>
           </View>
         </View>
+        <View
+          contrast={false}
+          status="default"
+          style={
+            Array [
+              Object {
+                "backgroundColor": "#000000",
+                "height": 0.5,
+              },
+            ]
+          }
+        />
       </View>
-      <View
-        contrast={false}
-        status="default"
-        style={
-          Array [
-            Object {
-              "backgroundColor": "#000000",
-              "height": 0.5,
-            },
-          ]
-        }
-      />
     </View>
   </View>
 </View>
@@ -1331,202 +1385,211 @@ exports[`<Search /> should render search with custom placeholder color 1`] = `
   }
 >
   <View
-    multiline={false}
     style={
       Array [
-        Object {
-          "justifyContent": "flex-start",
-          "paddingTop": 0,
-          "position": "relative",
-        },
-        Object {
-          "height": "90%",
-          "paddingBottom": 0,
-          "paddingLeft": 0,
-          "paddingRight": 0,
-          "paddingTop": 0,
-          "width": "100%",
-        },
+        Object {},
+        Object {},
       ]
     }
   >
     <View
-      borderedRadius={0}
-      error={false}
-      showBorderErrored={true}
+      multiline={false}
       style={
         Array [
           Object {
-            "borderColor": "black",
-            "borderStyle": "solid",
-            "borderWidth": 0,
+            "justifyContent": "flex-start",
+            "paddingTop": 0,
+            "position": "relative",
+          },
+          Object {
+            "height": "90%",
+            "paddingBottom": 0,
+            "paddingLeft": 0,
+            "paddingRight": 0,
+            "paddingTop": 0,
+            "width": "100%",
           },
         ]
       }
     >
-      <Text
-        accessibilityLabel="Erro "
-        collapsable={false}
-        contrast={false}
-        nativeID="animatedComponent"
-        status="default"
-        style={
-          Array [
-            Object {
-              "color": "#000000",
-              "fontSize": 15,
-              "lineHeight": 18,
-              "position": "absolute",
-              "top": 8,
-            },
-            Object {
-              "fontSize": 18,
-              "top": 8,
-            },
-          ]
-        }
-        testID="error_test"
-        variant="md"
-      />
       <View
-        multiline={false}
-        rightIcon={false}
+        borderedRadius={0}
+        error={false}
+        showBorderErrored={true}
         style={
           Array [
             Object {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "justifyContent": "center",
-              "maxWidth": "100%",
-              "overflow": "hidden",
-              "paddingLeft": 4,
-              "paddingRight": 4,
-              "paddingTop": 4,
+              "borderColor": "black",
+              "borderStyle": "solid",
+              "borderWidth": 0,
             },
           ]
         }
       >
-        <TextInput
-          accessibility=""
-          accessibilityLabel=""
-          allowFontScaling={false}
-          autoCapitalize="none"
-          autoCompleteType="off"
-          autoCorrect={false}
-          centered={false}
+        <Text
+          accessibilityLabel="Erro "
+          collapsable={false}
           contrast={false}
-          id="test"
-          inputRef="$text"
-          isPlaceholder={true}
-          keyboardType="default"
-          large={false}
-          multiline={false}
-          onBlur={[Function]}
-          onChangeText={[Function]}
-          onFocus={[Function]}
-          onSubmitEditing={[Function]}
-          placeholder=""
-          placeholderTextColor="#123983"
+          nativeID="animatedComponent"
           status="default"
           style={
             Array [
               Object {
-                "borderWidth": 0,
                 "color": "#000000",
-                "flexBasis": 0,
-                "flexGrow": 1,
-                "flexShrink": 1,
                 "fontSize": 15,
-                "marginTop": 0,
-                "minHeight": 37.714285714285715,
-                "paddingBottom": 0,
-                "paddingLeft": 0,
-                "paddingRight": 0,
-                "paddingTop": 0,
-                "width": "100%",
+                "lineHeight": 18,
+                "position": "absolute",
+                "top": 8,
               },
-              Object {},
+              Object {
+                "fontSize": 18,
+                "top": 8,
+              },
             ]
           }
-          testID="test"
-          textAlign="left"
-          type="no-mask"
-          underlineColorAndroid="transparent"
-          value=""
+          testID="error_test"
           variant="md"
-          withBottomline={true}
         />
         <View
-          collapsable={false}
-          nativeID="animatedComponent"
-          style={Object {}}
+          multiline={false}
+          rightIcon={false}
+          style={
+            Array [
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "justifyContent": "center",
+                "maxWidth": "100%",
+                "overflow": "hidden",
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
+              },
+            ]
+          }
         >
-          <View
-            accessibilityLabel="icon_"
-            accessibilityState={
-              Object {
-                "disabled": false,
-              }
-            }
-            accessible={true}
-            collapsable={false}
-            focusable={true}
-            hitSlop={Object {}}
-            nativeID="animatedComponent"
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
+          <TextInput
+            accessibility=""
+            accessibilityLabel=""
+            allowFontScaling={false}
+            autoCapitalize="none"
+            autoCompleteType="off"
+            autoCorrect={false}
+            centered={false}
+            contrast={false}
+            id="test"
+            inputRef="$text"
+            isPlaceholder={true}
+            keyboardType="default"
+            large={false}
+            multiline={false}
+            onBlur={[Function]}
+            onChangeText={[Function]}
+            onFocus={[Function]}
+            onSubmitEditing={[Function]}
+            placeholder=""
+            placeholderTextColor="#123983"
+            status="default"
             style={
-              Object {
-                "opacity": 1,
-              }
+              Array [
+                Object {
+                  "borderWidth": 0,
+                  "color": "#000000",
+                  "flexBasis": 0,
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                  "fontSize": 15,
+                  "marginTop": 0,
+                  "minHeight": 37.714285714285715,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "width": "100%",
+                },
+                Object {},
+              ]
             }
-            testID="id_magnify"
+            testID="test"
+            textAlign="left"
+            type="no-mask"
+            underlineColorAndroid="transparent"
+            value=""
+            variant="md"
+            withBottomline={true}
+          />
+          <View
+            collapsable={false}
+            nativeID="animatedComponent"
+            style={Object {}}
           >
-            <View>
-              <Text
-                allowFontScaling={false}
-                style={
-                  Array [
-                    Object {
-                      "color": "function (_ref) {
+            <View
+              accessibilityLabel="icon_"
+              accessibilityState={
+                Object {
+                  "disabled": false,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              hitSlop={Object {}}
+              nativeID="animatedComponent"
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                Object {
+                  "opacity": 1,
+                }
+              }
+              testID="id_magnify"
+            >
+              <View>
+                <Text
+                  allowFontScaling={false}
+                  style={
+                    Array [
+                      Object {
+                        "color": "function (_ref) {
     var theme = _ref.theme;
     return lodash_1(theme, themeProp);
   }",
-                      "fontSize": 40.85714285714286,
-                    },
-                    undefined,
-                    Object {
-                      "fontFamily": "Material Design Icons",
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                󰍉
-              </Text>
+                        "fontSize": 40.85714285714286,
+                      },
+                      undefined,
+                      Object {
+                        "fontFamily": "Material Design Icons",
+                        "fontStyle": "normal",
+                        "fontWeight": "normal",
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  󰍉
+                </Text>
+              </View>
             </View>
           </View>
         </View>
+        <View
+          contrast={false}
+          status="default"
+          style={
+            Array [
+              Object {
+                "backgroundColor": "#000000",
+                "height": 0.5,
+              },
+            ]
+          }
+        />
       </View>
-      <View
-        contrast={false}
-        status="default"
-        style={
-          Array [
-            Object {
-              "backgroundColor": "#000000",
-              "height": 0.5,
-            },
-          ]
-        }
-      />
     </View>
   </View>
 </View>
@@ -1552,198 +1615,207 @@ exports[`<Search /> should render search with custom text style 1`] = `
   }
 >
   <View
-    multiline={false}
     style={
       Array [
-        Object {
-          "justifyContent": "flex-start",
-          "paddingTop": 0,
-          "position": "relative",
-        },
-        Object {
-          "height": "90%",
-          "paddingBottom": 0,
-          "paddingLeft": 0,
-          "paddingRight": 0,
-          "paddingTop": 0,
-          "width": "100%",
-        },
+        Object {},
+        Object {},
       ]
     }
   >
     <View
-      borderedRadius={0}
-      error={false}
-      showBorderErrored={true}
+      multiline={false}
       style={
         Array [
           Object {
-            "borderColor": "black",
-            "borderStyle": "solid",
-            "borderWidth": 0,
+            "justifyContent": "flex-start",
+            "paddingTop": 0,
+            "position": "relative",
+          },
+          Object {
+            "height": "90%",
+            "paddingBottom": 0,
+            "paddingLeft": 0,
+            "paddingRight": 0,
+            "paddingTop": 0,
+            "width": "100%",
           },
         ]
       }
     >
-      <Text
-        accessibilityLabel="Erro "
-        contrast={false}
-        status="default"
-        style={
-          Array [
-            Object {
-              "color": "#000000",
-              "fontSize": 13,
-              "lineHeight": 15.6,
-              "position": "absolute",
-              "top": 8,
-            },
-            Object {
-              "fontSize": 18,
-              "top": 8,
-            },
-          ]
-        }
-        testID="error_test"
-        variant="xs"
-      />
       <View
-        multiline={false}
-        rightIcon={false}
+        borderedRadius={0}
+        error={false}
+        showBorderErrored={true}
         style={
           Array [
             Object {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "justifyContent": "center",
-              "maxWidth": "100%",
-              "overflow": "hidden",
-              "paddingLeft": 4,
-              "paddingRight": 4,
-              "paddingTop": 4,
+              "borderColor": "black",
+              "borderStyle": "solid",
+              "borderWidth": 0,
             },
           ]
         }
       >
-        <TextInput
-          accessibility=""
-          accessibilityLabel=""
-          allowFontScaling={false}
-          autoCapitalize="none"
-          autoCompleteType="off"
-          autoCorrect={false}
-          centered={false}
+        <Text
+          accessibilityLabel="Erro "
           contrast={false}
-          id="test"
-          inputRef="$text"
-          isPlaceholder={false}
-          keyboardType="default"
-          large={false}
-          multiline={false}
-          onBlur={[Function]}
-          onChangeText={[Function]}
-          onFocus={[Function]}
-          onSubmitEditing={[Function]}
-          placeholder="Pesquise aqui"
-          placeholderTextColor="#72727260"
           status="default"
           style={
             Array [
               Object {
-                "borderWidth": 0,
                 "color": "#000000",
-                "flexBasis": 0,
-                "flexGrow": 1,
-                "flexShrink": 1,
-                "fontSize": 15,
-                "marginTop": 0,
-                "minHeight": 37.714285714285715,
-                "paddingBottom": 0,
-                "paddingLeft": 0,
-                "paddingRight": 0,
-                "paddingTop": 0,
-                "width": "100%",
+                "fontSize": 13,
+                "lineHeight": 15.6,
+                "position": "absolute",
+                "top": 8,
               },
               Object {
-                "color": "#fff",
+                "fontSize": 18,
+                "top": 8,
               },
             ]
           }
-          testID="test"
-          textAlign="left"
-          type="no-mask"
-          underlineColorAndroid="transparent"
-          value=""
-          variant="md"
-          withBottomline={true}
+          testID="error_test"
+          variant="xs"
         />
         <View
-          style={Object {}}
+          multiline={false}
+          rightIcon={false}
+          style={
+            Array [
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "justifyContent": "center",
+                "maxWidth": "100%",
+                "overflow": "hidden",
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
+              },
+            ]
+          }
         >
-          <View
-            accessibilityLabel="icon_"
-            accessibilityState={
-              Object {
-                "disabled": false,
-              }
-            }
-            accessible={true}
-            focusable={true}
-            hitSlop={Object {}}
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
+          <TextInput
+            accessibility=""
+            accessibilityLabel=""
+            allowFontScaling={false}
+            autoCapitalize="none"
+            autoCompleteType="off"
+            autoCorrect={false}
+            centered={false}
+            contrast={false}
+            id="test"
+            inputRef="$text"
+            isPlaceholder={false}
+            keyboardType="default"
+            large={false}
+            multiline={false}
+            onBlur={[Function]}
+            onChangeText={[Function]}
+            onFocus={[Function]}
+            onSubmitEditing={[Function]}
+            placeholder="Pesquise aqui"
+            placeholderTextColor="#72727260"
+            status="default"
             style={
-              Object {
-                "opacity": 1,
-              }
+              Array [
+                Object {
+                  "borderWidth": 0,
+                  "color": "#000000",
+                  "flexBasis": 0,
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                  "fontSize": 15,
+                  "marginTop": 0,
+                  "minHeight": 37.714285714285715,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "width": "100%",
+                },
+                Object {
+                  "color": "#fff",
+                },
+              ]
             }
-            testID="id_magnify"
+            testID="test"
+            textAlign="left"
+            type="no-mask"
+            underlineColorAndroid="transparent"
+            value=""
+            variant="md"
+            withBottomline={true}
+          />
+          <View
+            style={Object {}}
           >
-            <View>
-              <Text
-                allowFontScaling={false}
-                style={
-                  Array [
-                    Object {
-                      "color": "function (_ref) {
+            <View
+              accessibilityLabel="icon_"
+              accessibilityState={
+                Object {
+                  "disabled": false,
+                }
+              }
+              accessible={true}
+              focusable={true}
+              hitSlop={Object {}}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                Object {
+                  "opacity": 1,
+                }
+              }
+              testID="id_magnify"
+            >
+              <View>
+                <Text
+                  allowFontScaling={false}
+                  style={
+                    Array [
+                      Object {
+                        "color": "function (_ref) {
     var theme = _ref.theme;
     return lodash_1(theme, themeProp);
   }",
-                      "fontSize": 40.85714285714286,
-                    },
-                    undefined,
-                    Object {
-                      "fontFamily": "Material Design Icons",
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                󰍉
-              </Text>
+                        "fontSize": 40.85714285714286,
+                      },
+                      undefined,
+                      Object {
+                        "fontFamily": "Material Design Icons",
+                        "fontStyle": "normal",
+                        "fontWeight": "normal",
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  󰍉
+                </Text>
+              </View>
             </View>
           </View>
         </View>
+        <View
+          contrast={false}
+          status="default"
+          style={
+            Array [
+              Object {
+                "backgroundColor": "#000000",
+                "height": 0.5,
+              },
+            ]
+          }
+        />
       </View>
-      <View
-        contrast={false}
-        status="default"
-        style={
-          Array [
-            Object {
-              "backgroundColor": "#000000",
-              "height": 0.5,
-            },
-          ]
-        }
-      />
     </View>
   </View>
 </View>
@@ -1769,196 +1841,205 @@ exports[`<Search /> should render search with icon size 1`] = `
   }
 >
   <View
-    multiline={false}
     style={
       Array [
-        Object {
-          "justifyContent": "flex-start",
-          "paddingTop": 0,
-          "position": "relative",
-        },
-        Object {
-          "height": "90%",
-          "paddingBottom": 0,
-          "paddingLeft": 0,
-          "paddingRight": 0,
-          "paddingTop": 0,
-          "width": "100%",
-        },
+        Object {},
+        Object {},
       ]
     }
   >
     <View
-      borderedRadius={0}
-      error={false}
-      showBorderErrored={true}
+      multiline={false}
       style={
         Array [
           Object {
-            "borderColor": "black",
-            "borderStyle": "solid",
-            "borderWidth": 0,
+            "justifyContent": "flex-start",
+            "paddingTop": 0,
+            "position": "relative",
+          },
+          Object {
+            "height": "90%",
+            "paddingBottom": 0,
+            "paddingLeft": 0,
+            "paddingRight": 0,
+            "paddingTop": 0,
+            "width": "100%",
           },
         ]
       }
     >
-      <Text
-        accessibilityLabel="Erro "
-        contrast={false}
-        status="default"
-        style={
-          Array [
-            Object {
-              "color": "#000000",
-              "fontSize": 13,
-              "lineHeight": 15.6,
-              "position": "absolute",
-              "top": 8,
-            },
-            Object {
-              "fontSize": 18,
-              "top": 8,
-            },
-          ]
-        }
-        testID="error_test"
-        variant="xs"
-      />
       <View
-        multiline={false}
-        rightIcon={false}
+        borderedRadius={0}
+        error={false}
+        showBorderErrored={true}
         style={
           Array [
             Object {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "justifyContent": "center",
-              "maxWidth": "100%",
-              "overflow": "hidden",
-              "paddingLeft": 4,
-              "paddingRight": 4,
-              "paddingTop": 4,
+              "borderColor": "black",
+              "borderStyle": "solid",
+              "borderWidth": 0,
             },
           ]
         }
       >
-        <TextInput
-          accessibility=""
-          accessibilityLabel=""
-          allowFontScaling={false}
-          autoCapitalize="none"
-          autoCompleteType="off"
-          autoCorrect={false}
-          centered={false}
+        <Text
+          accessibilityLabel="Erro "
           contrast={false}
-          id="test"
-          inputRef="$text"
-          isPlaceholder={false}
-          keyboardType="default"
-          large={false}
-          multiline={false}
-          onBlur={[Function]}
-          onChangeText={[Function]}
-          onFocus={[Function]}
-          onSubmitEditing={[Function]}
-          placeholder="Pesquise aqui"
-          placeholderTextColor="#72727260"
           status="default"
           style={
             Array [
               Object {
-                "borderWidth": 0,
                 "color": "#000000",
-                "flexBasis": 0,
-                "flexGrow": 1,
-                "flexShrink": 1,
-                "fontSize": 15,
-                "marginTop": 0,
-                "minHeight": 37.714285714285715,
-                "paddingBottom": 0,
-                "paddingLeft": 0,
-                "paddingRight": 0,
-                "paddingTop": 0,
-                "width": "100%",
+                "fontSize": 13,
+                "lineHeight": 15.6,
+                "position": "absolute",
+                "top": 8,
               },
-              Object {},
+              Object {
+                "fontSize": 18,
+                "top": 8,
+              },
             ]
           }
-          testID="test"
-          textAlign="left"
-          type="no-mask"
-          underlineColorAndroid="transparent"
-          value=""
-          variant="md"
-          withBottomline={true}
+          testID="error_test"
+          variant="xs"
         />
         <View
-          style={Object {}}
+          multiline={false}
+          rightIcon={false}
+          style={
+            Array [
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "justifyContent": "center",
+                "maxWidth": "100%",
+                "overflow": "hidden",
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
+              },
+            ]
+          }
         >
-          <View
-            accessibilityLabel="icon_"
-            accessibilityState={
-              Object {
-                "disabled": false,
-              }
-            }
-            accessible={true}
-            focusable={true}
-            hitSlop={Object {}}
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
+          <TextInput
+            accessibility=""
+            accessibilityLabel=""
+            allowFontScaling={false}
+            autoCapitalize="none"
+            autoCompleteType="off"
+            autoCorrect={false}
+            centered={false}
+            contrast={false}
+            id="test"
+            inputRef="$text"
+            isPlaceholder={false}
+            keyboardType="default"
+            large={false}
+            multiline={false}
+            onBlur={[Function]}
+            onChangeText={[Function]}
+            onFocus={[Function]}
+            onSubmitEditing={[Function]}
+            placeholder="Pesquise aqui"
+            placeholderTextColor="#72727260"
+            status="default"
             style={
-              Object {
-                "opacity": 1,
-              }
+              Array [
+                Object {
+                  "borderWidth": 0,
+                  "color": "#000000",
+                  "flexBasis": 0,
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                  "fontSize": 15,
+                  "marginTop": 0,
+                  "minHeight": 37.714285714285715,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "width": "100%",
+                },
+                Object {},
+              ]
             }
-            testID="id_magnify"
+            testID="test"
+            textAlign="left"
+            type="no-mask"
+            underlineColorAndroid="transparent"
+            value=""
+            variant="md"
+            withBottomline={true}
+          />
+          <View
+            style={Object {}}
           >
-            <View>
-              <Text
-                allowFontScaling={false}
-                style={
-                  Array [
-                    Object {
-                      "color": "function (_ref) {
+            <View
+              accessibilityLabel="icon_"
+              accessibilityState={
+                Object {
+                  "disabled": false,
+                }
+              }
+              accessible={true}
+              focusable={true}
+              hitSlop={Object {}}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                Object {
+                  "opacity": 1,
+                }
+              }
+              testID="id_magnify"
+            >
+              <View>
+                <Text
+                  allowFontScaling={false}
+                  style={
+                    Array [
+                      Object {
+                        "color": "function (_ref) {
     var theme = _ref.theme;
     return lodash_1(theme, themeProp);
   }",
-                      "fontSize": 24,
-                    },
-                    undefined,
-                    Object {
-                      "fontFamily": "Material Design Icons",
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                󰍉
-              </Text>
+                        "fontSize": 24,
+                      },
+                      undefined,
+                      Object {
+                        "fontFamily": "Material Design Icons",
+                        "fontStyle": "normal",
+                        "fontWeight": "normal",
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  󰍉
+                </Text>
+              </View>
             </View>
           </View>
         </View>
+        <View
+          contrast={false}
+          status="default"
+          style={
+            Array [
+              Object {
+                "backgroundColor": "#000000",
+                "height": 0.5,
+              },
+            ]
+          }
+        />
       </View>
-      <View
-        contrast={false}
-        status="default"
-        style={
-          Array [
-            Object {
-              "backgroundColor": "#000000",
-              "height": 0.5,
-            },
-          ]
-        }
-      />
     </View>
   </View>
 </View>
@@ -1984,193 +2065,202 @@ exports[`<Search /> should render search with left icon 1`] = `
   }
 >
   <View
-    multiline={false}
     style={
       Array [
-        Object {
-          "justifyContent": "flex-start",
-          "paddingTop": 0,
-          "position": "relative",
-        },
-        Object {
-          "height": "90%",
-          "paddingBottom": 0,
-          "paddingLeft": 0,
-          "paddingRight": 0,
-          "paddingTop": 0,
-          "width": "100%",
-        },
+        Object {},
+        Object {},
       ]
     }
   >
     <View
-      borderedRadius={0}
-      error={false}
-      showBorderErrored={true}
+      multiline={false}
       style={
         Array [
           Object {
-            "borderColor": "black",
-            "borderStyle": "solid",
-            "borderWidth": 0,
+            "justifyContent": "flex-start",
+            "paddingTop": 0,
+            "position": "relative",
+          },
+          Object {
+            "height": "90%",
+            "paddingBottom": 0,
+            "paddingLeft": 0,
+            "paddingRight": 0,
+            "paddingTop": 0,
+            "width": "100%",
           },
         ]
       }
     >
-      <Text
-        accessibilityLabel="Erro "
-        contrast={false}
-        status="default"
-        style={
-          Array [
-            Object {
-              "color": "#000000",
-              "fontSize": 13,
-              "lineHeight": 15.6,
-              "position": "absolute",
-              "top": 8,
-            },
-            Object {
-              "fontSize": 18,
-              "top": 8,
-            },
-          ]
-        }
-        testID="error_test"
-        variant="xs"
-      />
       <View
-        multiline={false}
-        rightIcon={false}
+        borderedRadius={0}
+        error={false}
+        showBorderErrored={true}
         style={
           Array [
             Object {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "justifyContent": "center",
-              "maxWidth": "100%",
-              "overflow": "hidden",
-              "paddingLeft": 4,
-              "paddingRight": 4,
-              "paddingTop": 4,
+              "borderColor": "black",
+              "borderStyle": "solid",
+              "borderWidth": 0,
             },
           ]
         }
       >
-        <View
-          style={Object {}}
-        >
-          <View
-            accessibilityLabel="icon_"
-            accessibilityState={
-              Object {
-                "disabled": false,
-              }
-            }
-            accessible={true}
-            focusable={true}
-            hitSlop={Object {}}
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              Object {
-                "opacity": 1,
-              }
-            }
-            testID="id_paperclip"
-          >
-            <View>
-              <Text
-                allowFontScaling={false}
-                style={
-                  Array [
-                    Object {
-                      "color": "#C6B09E",
-                      "fontSize": 40.85714285714286,
-                    },
-                    undefined,
-                    Object {
-                      "fontFamily": "Material Design Icons",
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                󰏢
-              </Text>
-            </View>
-          </View>
-        </View>
-        <TextInput
-          accessibility=""
-          accessibilityLabel=""
-          allowFontScaling={false}
-          autoCapitalize="none"
-          autoCompleteType="off"
-          autoCorrect={false}
-          centered={false}
+        <Text
+          accessibilityLabel="Erro "
           contrast={false}
-          id="test"
-          inputRef="$text"
-          isPlaceholder={false}
-          keyboardType="default"
-          large={false}
-          multiline={false}
-          onBlur={[Function]}
-          onChangeText={[Function]}
-          onFocus={[Function]}
-          onSubmitEditing={[Function]}
-          placeholder="Pesquise aqui"
-          placeholderTextColor="#72727260"
           status="default"
           style={
             Array [
               Object {
-                "borderWidth": 0,
                 "color": "#000000",
-                "flexBasis": 0,
-                "flexGrow": 1,
-                "flexShrink": 1,
-                "fontSize": 15,
-                "marginTop": 0,
-                "minHeight": 37.714285714285715,
-                "paddingBottom": 0,
-                "paddingLeft": 0,
-                "paddingRight": 0,
-                "paddingTop": 0,
-                "width": "100%",
+                "fontSize": 13,
+                "lineHeight": 15.6,
+                "position": "absolute",
+                "top": 8,
               },
-              Object {},
+              Object {
+                "fontSize": 18,
+                "top": 8,
+              },
             ]
           }
-          testID="test"
-          textAlign="left"
-          type="no-mask"
-          underlineColorAndroid="transparent"
-          value=""
-          variant="md"
-          withBottomline={true}
+          testID="error_test"
+          variant="xs"
+        />
+        <View
+          multiline={false}
+          rightIcon={false}
+          style={
+            Array [
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "justifyContent": "center",
+                "maxWidth": "100%",
+                "overflow": "hidden",
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
+              },
+            ]
+          }
+        >
+          <View
+            style={Object {}}
+          >
+            <View
+              accessibilityLabel="icon_"
+              accessibilityState={
+                Object {
+                  "disabled": false,
+                }
+              }
+              accessible={true}
+              focusable={true}
+              hitSlop={Object {}}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                Object {
+                  "opacity": 1,
+                }
+              }
+              testID="id_paperclip"
+            >
+              <View>
+                <Text
+                  allowFontScaling={false}
+                  style={
+                    Array [
+                      Object {
+                        "color": "#C6B09E",
+                        "fontSize": 40.85714285714286,
+                      },
+                      undefined,
+                      Object {
+                        "fontFamily": "Material Design Icons",
+                        "fontStyle": "normal",
+                        "fontWeight": "normal",
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  󰏢
+                </Text>
+              </View>
+            </View>
+          </View>
+          <TextInput
+            accessibility=""
+            accessibilityLabel=""
+            allowFontScaling={false}
+            autoCapitalize="none"
+            autoCompleteType="off"
+            autoCorrect={false}
+            centered={false}
+            contrast={false}
+            id="test"
+            inputRef="$text"
+            isPlaceholder={false}
+            keyboardType="default"
+            large={false}
+            multiline={false}
+            onBlur={[Function]}
+            onChangeText={[Function]}
+            onFocus={[Function]}
+            onSubmitEditing={[Function]}
+            placeholder="Pesquise aqui"
+            placeholderTextColor="#72727260"
+            status="default"
+            style={
+              Array [
+                Object {
+                  "borderWidth": 0,
+                  "color": "#000000",
+                  "flexBasis": 0,
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                  "fontSize": 15,
+                  "marginTop": 0,
+                  "minHeight": 37.714285714285715,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "width": "100%",
+                },
+                Object {},
+              ]
+            }
+            testID="test"
+            textAlign="left"
+            type="no-mask"
+            underlineColorAndroid="transparent"
+            value=""
+            variant="md"
+            withBottomline={true}
+          />
+        </View>
+        <View
+          contrast={false}
+          status="default"
+          style={
+            Array [
+              Object {
+                "backgroundColor": "#000000",
+                "height": 0.5,
+              },
+            ]
+          }
         />
       </View>
-      <View
-        contrast={false}
-        status="default"
-        style={
-          Array [
-            Object {
-              "backgroundColor": "#000000",
-              "height": 0.5,
-            },
-          ]
-        }
-      />
     </View>
   </View>
 </View>
@@ -2197,203 +2287,212 @@ exports[`<Search /> should render search with padding 1`] = `
   }
 >
   <View
-    multiline={false}
     style={
       Array [
-        Object {
-          "justifyContent": "flex-start",
-          "paddingTop": 0,
-          "position": "relative",
-        },
-        Object {
-          "height": "90%",
-          "paddingBottom": 0,
-          "paddingLeft": 0,
-          "paddingRight": 0,
-          "paddingTop": 0,
-          "width": "100%",
-        },
+        Object {},
+        Object {},
       ]
     }
   >
     <View
-      borderedRadius={0}
-      error={false}
-      showBorderErrored={true}
+      multiline={false}
       style={
         Array [
           Object {
-            "borderColor": "black",
-            "borderStyle": "solid",
-            "borderWidth": 0,
+            "justifyContent": "flex-start",
+            "paddingTop": 0,
+            "position": "relative",
+          },
+          Object {
+            "height": "90%",
+            "paddingBottom": 0,
+            "paddingLeft": 0,
+            "paddingRight": 0,
+            "paddingTop": 0,
+            "width": "100%",
           },
         ]
       }
     >
-      <Text
-        accessibilityLabel="Erro "
-        collapsable={false}
-        contrast={false}
-        nativeID="animatedComponent"
-        status="default"
-        style={
-          Array [
-            Object {
-              "color": "#000000",
-              "fontSize": 15,
-              "lineHeight": 18,
-              "position": "absolute",
-              "top": 8,
-            },
-            Object {
-              "fontSize": 18,
-              "top": 8,
-            },
-          ]
-        }
-        testID="error_test"
-        variant="md"
-      />
       <View
-        multiline={false}
-        padding={24}
-        rightIcon={false}
+        borderedRadius={0}
+        error={false}
+        showBorderErrored={true}
         style={
           Array [
             Object {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "justifyContent": "center",
-              "maxWidth": "100%",
-              "overflow": "hidden",
-              "paddingLeft": 24,
-              "paddingRight": 24,
-              "paddingTop": 24,
+              "borderColor": "black",
+              "borderStyle": "solid",
+              "borderWidth": 0,
             },
           ]
         }
       >
-        <TextInput
-          accessibility=""
-          accessibilityLabel=""
-          allowFontScaling={false}
-          autoCapitalize="none"
-          autoCompleteType="off"
-          autoCorrect={false}
-          centered={false}
+        <Text
+          accessibilityLabel="Erro "
+          collapsable={false}
           contrast={false}
-          id="test"
-          inputRef="$text"
-          isPlaceholder={true}
-          keyboardType="default"
-          large={false}
-          multiline={false}
-          onBlur={[Function]}
-          onChangeText={[Function]}
-          onFocus={[Function]}
-          onSubmitEditing={[Function]}
-          placeholder=""
-          placeholderTextColor="#72727260"
+          nativeID="animatedComponent"
           status="default"
           style={
             Array [
               Object {
-                "borderWidth": 0,
                 "color": "#000000",
-                "flexBasis": 0,
-                "flexGrow": 1,
-                "flexShrink": 1,
                 "fontSize": 15,
-                "marginTop": 0,
-                "minHeight": 37.714285714285715,
-                "paddingBottom": 0,
-                "paddingLeft": 0,
-                "paddingRight": 0,
-                "paddingTop": 0,
-                "width": "100%",
+                "lineHeight": 18,
+                "position": "absolute",
+                "top": 8,
               },
-              Object {},
+              Object {
+                "fontSize": 18,
+                "top": 8,
+              },
             ]
           }
-          testID="test"
-          textAlign="left"
-          type="no-mask"
-          underlineColorAndroid="transparent"
-          value=""
+          testID="error_test"
           variant="md"
-          withBottomline={true}
         />
         <View
-          collapsable={false}
-          nativeID="animatedComponent"
-          style={Object {}}
+          multiline={false}
+          padding={24}
+          rightIcon={false}
+          style={
+            Array [
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "justifyContent": "center",
+                "maxWidth": "100%",
+                "overflow": "hidden",
+                "paddingLeft": 24,
+                "paddingRight": 24,
+                "paddingTop": 24,
+              },
+            ]
+          }
         >
-          <View
-            accessibilityLabel="icon_"
-            accessibilityState={
-              Object {
-                "disabled": false,
-              }
-            }
-            accessible={true}
-            collapsable={false}
-            focusable={true}
-            hitSlop={Object {}}
-            nativeID="animatedComponent"
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
+          <TextInput
+            accessibility=""
+            accessibilityLabel=""
+            allowFontScaling={false}
+            autoCapitalize="none"
+            autoCompleteType="off"
+            autoCorrect={false}
+            centered={false}
+            contrast={false}
+            id="test"
+            inputRef="$text"
+            isPlaceholder={true}
+            keyboardType="default"
+            large={false}
+            multiline={false}
+            onBlur={[Function]}
+            onChangeText={[Function]}
+            onFocus={[Function]}
+            onSubmitEditing={[Function]}
+            placeholder=""
+            placeholderTextColor="#72727260"
+            status="default"
             style={
-              Object {
-                "opacity": 1,
-              }
+              Array [
+                Object {
+                  "borderWidth": 0,
+                  "color": "#000000",
+                  "flexBasis": 0,
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                  "fontSize": 15,
+                  "marginTop": 0,
+                  "minHeight": 37.714285714285715,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "width": "100%",
+                },
+                Object {},
+              ]
             }
-            testID="id_magnify"
+            testID="test"
+            textAlign="left"
+            type="no-mask"
+            underlineColorAndroid="transparent"
+            value=""
+            variant="md"
+            withBottomline={true}
+          />
+          <View
+            collapsable={false}
+            nativeID="animatedComponent"
+            style={Object {}}
           >
-            <View>
-              <Text
-                allowFontScaling={false}
-                style={
-                  Array [
-                    Object {
-                      "color": "function (_ref) {
+            <View
+              accessibilityLabel="icon_"
+              accessibilityState={
+                Object {
+                  "disabled": false,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              hitSlop={Object {}}
+              nativeID="animatedComponent"
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                Object {
+                  "opacity": 1,
+                }
+              }
+              testID="id_magnify"
+            >
+              <View>
+                <Text
+                  allowFontScaling={false}
+                  style={
+                    Array [
+                      Object {
+                        "color": "function (_ref) {
     var theme = _ref.theme;
     return lodash_1(theme, themeProp);
   }",
-                      "fontSize": 40.85714285714286,
-                    },
-                    undefined,
-                    Object {
-                      "fontFamily": "Material Design Icons",
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                󰍉
-              </Text>
+                        "fontSize": 40.85714285714286,
+                      },
+                      undefined,
+                      Object {
+                        "fontFamily": "Material Design Icons",
+                        "fontStyle": "normal",
+                        "fontWeight": "normal",
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  󰍉
+                </Text>
+              </View>
             </View>
           </View>
         </View>
+        <View
+          contrast={false}
+          status="default"
+          style={
+            Array [
+              Object {
+                "backgroundColor": "#000000",
+                "height": 0.5,
+              },
+            ]
+          }
+        />
       </View>
-      <View
-        contrast={false}
-        status="default"
-        style={
-          Array [
-            Object {
-              "backgroundColor": "#000000",
-              "height": 0.5,
-            },
-          ]
-        }
-      />
     </View>
   </View>
 </View>
@@ -2419,202 +2518,211 @@ exports[`<Search /> should render search with right icon 1`] = `
   }
 >
   <View
-    multiline={false}
     style={
       Array [
-        Object {
-          "justifyContent": "flex-start",
-          "paddingTop": 0,
-          "position": "relative",
-        },
-        Object {
-          "height": "90%",
-          "paddingBottom": 0,
-          "paddingLeft": 0,
-          "paddingRight": 0,
-          "paddingTop": 0,
-          "width": "100%",
-        },
+        Object {},
+        Object {},
       ]
     }
   >
     <View
-      borderedRadius={0}
-      error={false}
-      showBorderErrored={true}
+      multiline={false}
       style={
         Array [
           Object {
-            "borderColor": "black",
-            "borderStyle": "solid",
-            "borderWidth": 0,
+            "justifyContent": "flex-start",
+            "paddingTop": 0,
+            "position": "relative",
+          },
+          Object {
+            "height": "90%",
+            "paddingBottom": 0,
+            "paddingLeft": 0,
+            "paddingRight": 0,
+            "paddingTop": 0,
+            "width": "100%",
           },
         ]
       }
     >
-      <Text
-        accessibilityLabel="Erro "
-        collapsable={false}
-        contrast={false}
-        nativeID="animatedComponent"
-        status="default"
-        style={
-          Array [
-            Object {
-              "color": "#000000",
-              "fontSize": 15,
-              "lineHeight": 18,
-              "position": "absolute",
-              "top": 8,
-            },
-            Object {
-              "fontSize": 18,
-              "top": 8,
-            },
-          ]
-        }
-        testID="error_test"
-        variant="md"
-      />
       <View
-        multiline={false}
-        rightIcon={true}
+        borderedRadius={0}
+        error={false}
+        showBorderErrored={true}
         style={
           Array [
             Object {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "justifyContent": "center",
-              "maxWidth": "100%",
-              "overflow": "hidden",
-              "paddingLeft": 4,
-              "paddingRight": 4,
-              "paddingTop": 4,
+              "borderColor": "black",
+              "borderStyle": "solid",
+              "borderWidth": 0,
             },
           ]
         }
       >
-        <TextInput
-          accessibility=""
-          accessibilityLabel=""
-          allowFontScaling={false}
-          autoCapitalize="none"
-          autoCompleteType="off"
-          autoCorrect={false}
-          centered={false}
+        <Text
+          accessibilityLabel="Erro "
+          collapsable={false}
           contrast={false}
-          id="test"
-          inputRef="$text"
-          isPlaceholder={true}
-          keyboardType="default"
-          large={false}
-          multiline={false}
-          onBlur={[Function]}
-          onChangeText={[Function]}
-          onFocus={[Function]}
-          onSubmitEditing={[Function]}
-          placeholder=""
-          placeholderTextColor="#72727260"
+          nativeID="animatedComponent"
           status="default"
           style={
             Array [
               Object {
-                "borderWidth": 0,
                 "color": "#000000",
-                "flexBasis": 0,
-                "flexGrow": 1,
-                "flexShrink": 1,
                 "fontSize": 15,
-                "marginTop": 0,
-                "minHeight": 37.714285714285715,
-                "paddingBottom": 0,
-                "paddingLeft": 0,
-                "paddingRight": 0,
-                "paddingTop": 0,
-                "width": "100%",
+                "lineHeight": 18,
+                "position": "absolute",
+                "top": 8,
               },
-              Object {},
+              Object {
+                "fontSize": 18,
+                "top": 8,
+              },
             ]
           }
-          testID="test"
-          textAlign="left"
-          type="no-mask"
-          underlineColorAndroid="transparent"
-          value=""
+          testID="error_test"
           variant="md"
-          withBottomline={true}
         />
         <View
-          collapsable={false}
-          nativeID="animatedComponent"
-          style={Object {}}
+          multiline={false}
+          rightIcon={true}
+          style={
+            Array [
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "justifyContent": "center",
+                "maxWidth": "100%",
+                "overflow": "hidden",
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
+              },
+            ]
+          }
         >
-          <View
-            accessibilityLabel="icon_"
-            accessibilityState={
-              Object {
-                "disabled": false,
-              }
-            }
-            accessible={true}
-            collapsable={false}
-            focusable={true}
-            hitSlop={Object {}}
-            nativeID="animatedComponent"
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
+          <TextInput
+            accessibility=""
+            accessibilityLabel=""
+            allowFontScaling={false}
+            autoCapitalize="none"
+            autoCompleteType="off"
+            autoCorrect={false}
+            centered={false}
+            contrast={false}
+            id="test"
+            inputRef="$text"
+            isPlaceholder={true}
+            keyboardType="default"
+            large={false}
+            multiline={false}
+            onBlur={[Function]}
+            onChangeText={[Function]}
+            onFocus={[Function]}
+            onSubmitEditing={[Function]}
+            placeholder=""
+            placeholderTextColor="#72727260"
+            status="default"
             style={
-              Object {
-                "opacity": 1,
-              }
+              Array [
+                Object {
+                  "borderWidth": 0,
+                  "color": "#000000",
+                  "flexBasis": 0,
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                  "fontSize": 15,
+                  "marginTop": 0,
+                  "minHeight": 37.714285714285715,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "width": "100%",
+                },
+                Object {},
+              ]
             }
-            testID="id_parachute"
+            testID="test"
+            textAlign="left"
+            type="no-mask"
+            underlineColorAndroid="transparent"
+            value=""
+            variant="md"
+            withBottomline={true}
+          />
+          <View
+            collapsable={false}
+            nativeID="animatedComponent"
+            style={Object {}}
           >
-            <View>
-              <Text
-                allowFontScaling={false}
-                style={
-                  Array [
-                    Object {
-                      "color": "function (_ref) {
+            <View
+              accessibilityLabel="icon_"
+              accessibilityState={
+                Object {
+                  "disabled": false,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              hitSlop={Object {}}
+              nativeID="animatedComponent"
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                Object {
+                  "opacity": 1,
+                }
+              }
+              testID="id_parachute"
+            >
+              <View>
+                <Text
+                  allowFontScaling={false}
+                  style={
+                    Array [
+                      Object {
+                        "color": "function (_ref) {
     var theme = _ref.theme;
     return lodash_1(theme, themeProp);
   }",
-                      "fontSize": 40.85714285714286,
-                    },
-                    undefined,
-                    Object {
-                      "fontFamily": "Material Design Icons",
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                󰲴
-              </Text>
+                        "fontSize": 40.85714285714286,
+                      },
+                      undefined,
+                      Object {
+                        "fontFamily": "Material Design Icons",
+                        "fontStyle": "normal",
+                        "fontWeight": "normal",
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  󰲴
+                </Text>
+              </View>
             </View>
           </View>
         </View>
+        <View
+          contrast={false}
+          status="default"
+          style={
+            Array [
+              Object {
+                "backgroundColor": "#000000",
+                "height": 0.5,
+              },
+            ]
+          }
+        />
       </View>
-      <View
-        contrast={false}
-        status="default"
-        style={
-          Array [
-            Object {
-              "backgroundColor": "#000000",
-              "height": 0.5,
-            },
-          ]
-        }
-      />
     </View>
   </View>
 </View>
@@ -2647,202 +2755,211 @@ exports[`<Search /> should render search with shadow 1`] = `
   }
 >
   <View
-    multiline={false}
     style={
       Array [
-        Object {
-          "justifyContent": "flex-start",
-          "paddingTop": 0,
-          "position": "relative",
-        },
-        Object {
-          "height": "90%",
-          "paddingBottom": 0,
-          "paddingLeft": 0,
-          "paddingRight": 0,
-          "paddingTop": 0,
-          "width": "100%",
-        },
+        Object {},
+        Object {},
       ]
     }
   >
     <View
-      borderedRadius={0}
-      error={false}
-      showBorderErrored={true}
+      multiline={false}
       style={
         Array [
           Object {
-            "borderColor": "black",
-            "borderStyle": "solid",
-            "borderWidth": 0,
+            "justifyContent": "flex-start",
+            "paddingTop": 0,
+            "position": "relative",
+          },
+          Object {
+            "height": "90%",
+            "paddingBottom": 0,
+            "paddingLeft": 0,
+            "paddingRight": 0,
+            "paddingTop": 0,
+            "width": "100%",
           },
         ]
       }
     >
-      <Text
-        accessibilityLabel="Erro "
-        collapsable={false}
-        contrast={false}
-        nativeID="animatedComponent"
-        status="default"
-        style={
-          Array [
-            Object {
-              "color": "#000000",
-              "fontSize": 15,
-              "lineHeight": 18,
-              "position": "absolute",
-              "top": 8,
-            },
-            Object {
-              "fontSize": 18,
-              "top": 8,
-            },
-          ]
-        }
-        testID="error_test"
-        variant="md"
-      />
       <View
-        multiline={false}
-        rightIcon={false}
+        borderedRadius={0}
+        error={false}
+        showBorderErrored={true}
         style={
           Array [
             Object {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "justifyContent": "center",
-              "maxWidth": "100%",
-              "overflow": "hidden",
-              "paddingLeft": 4,
-              "paddingRight": 4,
-              "paddingTop": 4,
+              "borderColor": "black",
+              "borderStyle": "solid",
+              "borderWidth": 0,
             },
           ]
         }
       >
-        <TextInput
-          accessibility=""
-          accessibilityLabel=""
-          allowFontScaling={false}
-          autoCapitalize="none"
-          autoCompleteType="off"
-          autoCorrect={false}
-          centered={false}
+        <Text
+          accessibilityLabel="Erro "
+          collapsable={false}
           contrast={false}
-          id="test"
-          inputRef="$text"
-          isPlaceholder={true}
-          keyboardType="default"
-          large={false}
-          multiline={false}
-          onBlur={[Function]}
-          onChangeText={[Function]}
-          onFocus={[Function]}
-          onSubmitEditing={[Function]}
-          placeholder=""
-          placeholderTextColor="#72727260"
+          nativeID="animatedComponent"
           status="default"
           style={
             Array [
               Object {
-                "borderWidth": 0,
                 "color": "#000000",
-                "flexBasis": 0,
-                "flexGrow": 1,
-                "flexShrink": 1,
                 "fontSize": 15,
-                "marginTop": 0,
-                "minHeight": 37.714285714285715,
-                "paddingBottom": 0,
-                "paddingLeft": 0,
-                "paddingRight": 0,
-                "paddingTop": 0,
-                "width": "100%",
+                "lineHeight": 18,
+                "position": "absolute",
+                "top": 8,
               },
-              Object {},
+              Object {
+                "fontSize": 18,
+                "top": 8,
+              },
             ]
           }
-          testID="test"
-          textAlign="left"
-          type="no-mask"
-          underlineColorAndroid="transparent"
-          value=""
+          testID="error_test"
           variant="md"
-          withBottomline={true}
         />
         <View
-          collapsable={false}
-          nativeID="animatedComponent"
-          style={Object {}}
+          multiline={false}
+          rightIcon={false}
+          style={
+            Array [
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "justifyContent": "center",
+                "maxWidth": "100%",
+                "overflow": "hidden",
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
+              },
+            ]
+          }
         >
-          <View
-            accessibilityLabel="icon_"
-            accessibilityState={
-              Object {
-                "disabled": false,
-              }
-            }
-            accessible={true}
-            collapsable={false}
-            focusable={true}
-            hitSlop={Object {}}
-            nativeID="animatedComponent"
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
+          <TextInput
+            accessibility=""
+            accessibilityLabel=""
+            allowFontScaling={false}
+            autoCapitalize="none"
+            autoCompleteType="off"
+            autoCorrect={false}
+            centered={false}
+            contrast={false}
+            id="test"
+            inputRef="$text"
+            isPlaceholder={true}
+            keyboardType="default"
+            large={false}
+            multiline={false}
+            onBlur={[Function]}
+            onChangeText={[Function]}
+            onFocus={[Function]}
+            onSubmitEditing={[Function]}
+            placeholder=""
+            placeholderTextColor="#72727260"
+            status="default"
             style={
-              Object {
-                "opacity": 1,
-              }
+              Array [
+                Object {
+                  "borderWidth": 0,
+                  "color": "#000000",
+                  "flexBasis": 0,
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                  "fontSize": 15,
+                  "marginTop": 0,
+                  "minHeight": 37.714285714285715,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "width": "100%",
+                },
+                Object {},
+              ]
             }
-            testID="id_magnify"
+            testID="test"
+            textAlign="left"
+            type="no-mask"
+            underlineColorAndroid="transparent"
+            value=""
+            variant="md"
+            withBottomline={true}
+          />
+          <View
+            collapsable={false}
+            nativeID="animatedComponent"
+            style={Object {}}
           >
-            <View>
-              <Text
-                allowFontScaling={false}
-                style={
-                  Array [
-                    Object {
-                      "color": "function (_ref) {
+            <View
+              accessibilityLabel="icon_"
+              accessibilityState={
+                Object {
+                  "disabled": false,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              hitSlop={Object {}}
+              nativeID="animatedComponent"
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                Object {
+                  "opacity": 1,
+                }
+              }
+              testID="id_magnify"
+            >
+              <View>
+                <Text
+                  allowFontScaling={false}
+                  style={
+                    Array [
+                      Object {
+                        "color": "function (_ref) {
     var theme = _ref.theme;
     return lodash_1(theme, themeProp);
   }",
-                      "fontSize": 40.85714285714286,
-                    },
-                    undefined,
-                    Object {
-                      "fontFamily": "Material Design Icons",
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                󰍉
-              </Text>
+                        "fontSize": 40.85714285714286,
+                      },
+                      undefined,
+                      Object {
+                        "fontFamily": "Material Design Icons",
+                        "fontStyle": "normal",
+                        "fontWeight": "normal",
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  󰍉
+                </Text>
+              </View>
             </View>
           </View>
         </View>
+        <View
+          contrast={false}
+          status="default"
+          style={
+            Array [
+              Object {
+                "backgroundColor": "#000000",
+                "height": 0.5,
+              },
+            ]
+          }
+        />
       </View>
-      <View
-        contrast={false}
-        status="default"
-        style={
-          Array [
-            Object {
-              "backgroundColor": "#000000",
-              "height": 0.5,
-            },
-          ]
-        }
-      />
     </View>
   </View>
 </View>
@@ -2869,196 +2986,205 @@ exports[`<Search /> should render search with wrapper height 1`] = `
   }
 >
   <View
-    multiline={false}
     style={
       Array [
-        Object {
-          "justifyContent": "flex-start",
-          "paddingTop": 0,
-          "position": "relative",
-        },
-        Object {
-          "height": "90%",
-          "paddingBottom": 0,
-          "paddingLeft": 0,
-          "paddingRight": 0,
-          "paddingTop": 0,
-          "width": "100%",
-        },
+        Object {},
+        Object {},
       ]
     }
   >
     <View
-      borderedRadius={0}
-      error={false}
-      showBorderErrored={true}
+      multiline={false}
       style={
         Array [
           Object {
-            "borderColor": "black",
-            "borderStyle": "solid",
-            "borderWidth": 0,
+            "justifyContent": "flex-start",
+            "paddingTop": 0,
+            "position": "relative",
+          },
+          Object {
+            "height": "90%",
+            "paddingBottom": 0,
+            "paddingLeft": 0,
+            "paddingRight": 0,
+            "paddingTop": 0,
+            "width": "100%",
           },
         ]
       }
     >
-      <Text
-        accessibilityLabel="Erro "
-        contrast={false}
-        status="default"
-        style={
-          Array [
-            Object {
-              "color": "#000000",
-              "fontSize": 13,
-              "lineHeight": 15.6,
-              "position": "absolute",
-              "top": 8,
-            },
-            Object {
-              "fontSize": 18,
-              "top": 8,
-            },
-          ]
-        }
-        testID="error_test"
-        variant="xs"
-      />
       <View
-        multiline={false}
-        rightIcon={false}
+        borderedRadius={0}
+        error={false}
+        showBorderErrored={true}
         style={
           Array [
             Object {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "justifyContent": "center",
-              "maxWidth": "100%",
-              "overflow": "hidden",
-              "paddingLeft": 4,
-              "paddingRight": 4,
-              "paddingTop": 4,
+              "borderColor": "black",
+              "borderStyle": "solid",
+              "borderWidth": 0,
             },
           ]
         }
       >
-        <TextInput
-          accessibility=""
-          accessibilityLabel=""
-          allowFontScaling={false}
-          autoCapitalize="none"
-          autoCompleteType="off"
-          autoCorrect={false}
-          centered={false}
+        <Text
+          accessibilityLabel="Erro "
           contrast={false}
-          id="test"
-          inputRef="$text"
-          isPlaceholder={false}
-          keyboardType="default"
-          large={false}
-          multiline={false}
-          onBlur={[Function]}
-          onChangeText={[Function]}
-          onFocus={[Function]}
-          onSubmitEditing={[Function]}
-          placeholder="Pesquise aqui"
-          placeholderTextColor="#72727260"
           status="default"
           style={
             Array [
               Object {
-                "borderWidth": 0,
                 "color": "#000000",
-                "flexBasis": 0,
-                "flexGrow": 1,
-                "flexShrink": 1,
-                "fontSize": 15,
-                "marginTop": 0,
-                "minHeight": 37.714285714285715,
-                "paddingBottom": 0,
-                "paddingLeft": 0,
-                "paddingRight": 0,
-                "paddingTop": 0,
-                "width": "100%",
+                "fontSize": 13,
+                "lineHeight": 15.6,
+                "position": "absolute",
+                "top": 8,
               },
-              Object {},
+              Object {
+                "fontSize": 18,
+                "top": 8,
+              },
             ]
           }
-          testID="test"
-          textAlign="left"
-          type="no-mask"
-          underlineColorAndroid="transparent"
-          value=""
-          variant="md"
-          withBottomline={true}
+          testID="error_test"
+          variant="xs"
         />
         <View
-          style={Object {}}
+          multiline={false}
+          rightIcon={false}
+          style={
+            Array [
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "justifyContent": "center",
+                "maxWidth": "100%",
+                "overflow": "hidden",
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
+              },
+            ]
+          }
         >
-          <View
-            accessibilityLabel="icon_"
-            accessibilityState={
-              Object {
-                "disabled": false,
-              }
-            }
-            accessible={true}
-            focusable={true}
-            hitSlop={Object {}}
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
+          <TextInput
+            accessibility=""
+            accessibilityLabel=""
+            allowFontScaling={false}
+            autoCapitalize="none"
+            autoCompleteType="off"
+            autoCorrect={false}
+            centered={false}
+            contrast={false}
+            id="test"
+            inputRef="$text"
+            isPlaceholder={false}
+            keyboardType="default"
+            large={false}
+            multiline={false}
+            onBlur={[Function]}
+            onChangeText={[Function]}
+            onFocus={[Function]}
+            onSubmitEditing={[Function]}
+            placeholder="Pesquise aqui"
+            placeholderTextColor="#72727260"
+            status="default"
             style={
-              Object {
-                "opacity": 1,
-              }
+              Array [
+                Object {
+                  "borderWidth": 0,
+                  "color": "#000000",
+                  "flexBasis": 0,
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                  "fontSize": 15,
+                  "marginTop": 0,
+                  "minHeight": 37.714285714285715,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "width": "100%",
+                },
+                Object {},
+              ]
             }
-            testID="id_magnify"
+            testID="test"
+            textAlign="left"
+            type="no-mask"
+            underlineColorAndroid="transparent"
+            value=""
+            variant="md"
+            withBottomline={true}
+          />
+          <View
+            style={Object {}}
           >
-            <View>
-              <Text
-                allowFontScaling={false}
-                style={
-                  Array [
-                    Object {
-                      "color": "function (_ref) {
+            <View
+              accessibilityLabel="icon_"
+              accessibilityState={
+                Object {
+                  "disabled": false,
+                }
+              }
+              accessible={true}
+              focusable={true}
+              hitSlop={Object {}}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                Object {
+                  "opacity": 1,
+                }
+              }
+              testID="id_magnify"
+            >
+              <View>
+                <Text
+                  allowFontScaling={false}
+                  style={
+                    Array [
+                      Object {
+                        "color": "function (_ref) {
     var theme = _ref.theme;
     return lodash_1(theme, themeProp);
   }",
-                      "fontSize": 40.85714285714286,
-                    },
-                    undefined,
-                    Object {
-                      "fontFamily": "Material Design Icons",
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                󰍉
-              </Text>
+                        "fontSize": 40.85714285714286,
+                      },
+                      undefined,
+                      Object {
+                        "fontFamily": "Material Design Icons",
+                        "fontStyle": "normal",
+                        "fontWeight": "normal",
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  󰍉
+                </Text>
+              </View>
             </View>
           </View>
         </View>
+        <View
+          contrast={false}
+          status="default"
+          style={
+            Array [
+              Object {
+                "backgroundColor": "#000000",
+                "height": 0.5,
+              },
+            ]
+          }
+        />
       </View>
-      <View
-        contrast={false}
-        status="default"
-        style={
-          Array [
-            Object {
-              "backgroundColor": "#000000",
-              "height": 0.5,
-            },
-          ]
-        }
-      />
     </View>
   </View>
 </View>

--- a/src/components/TextInput/__tests__/__snapshots__/PasswordInput.spec.tsx.snap
+++ b/src/components/TextInput/__tests__/__snapshots__/PasswordInput.spec.tsx.snap
@@ -2,196 +2,205 @@
 
 exports[`<PasswordInput /> should render PasswordInput 1`] = `
 <View
-  multiline={false}
   style={
     Array [
-      Object {
-        "justifyContent": "flex-start",
-        "paddingTop": 0,
-        "position": "relative",
-      },
+      Object {},
       Object {},
     ]
   }
 >
   <View
-    borderedRadius={0}
-    error={false}
-    showBorderErrored={true}
+    multiline={false}
     style={
       Array [
         Object {
-          "borderColor": "black",
-          "borderStyle": "solid",
-          "borderWidth": 0,
+          "justifyContent": "flex-start",
+          "paddingTop": 0,
+          "position": "relative",
         },
+        Object {},
       ]
     }
   >
-    <Text
-      accessibilityLabel="Erro test"
-      collapsable={false}
-      contrast={false}
-      nativeID="animatedComponent"
-      status="default"
-      style={
-        Array [
-          Object {
-            "color": "#000000",
-            "fontSize": 15,
-            "lineHeight": 18,
-            "position": "absolute",
-            "top": 8,
-          },
-          Object {
-            "fontSize": 18,
-            "top": 8,
-          },
-        ]
-      }
-      testID="error_test"
-      variant="md"
-    />
     <View
-      multiline={false}
-      rightIcon={true}
+      borderedRadius={0}
+      error={false}
+      showBorderErrored={true}
       style={
         Array [
           Object {
-            "alignItems": "center",
-            "flexDirection": "row",
-            "justifyContent": "center",
-            "maxWidth": "100%",
-            "overflow": "hidden",
-            "paddingLeft": 4,
-            "paddingRight": 4,
-            "paddingTop": 4,
+            "borderColor": "black",
+            "borderStyle": "solid",
+            "borderWidth": 0,
           },
         ]
       }
     >
-      <TextInput
-        accessibility="test"
-        accessibilityLabel="test"
-        allowFontScaling={false}
-        centered={false}
+      <Text
+        accessibilityLabel="Erro test"
+        collapsable={false}
         contrast={false}
-        id="test"
-        inputRef="$text"
-        isPlaceholder={true}
-        keyboardType="default"
-        large={false}
-        multiline={false}
-        onBlur={[Function]}
-        onChangeText={[Function]}
-        onFocus={[Function]}
-        placeholder=""
-        placeholderTextColor="#72727260"
-        secureTextEntry={true}
+        nativeID="animatedComponent"
         status="default"
         style={
           Array [
             Object {
-              "borderWidth": 0,
               "color": "#000000",
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "fontSize": 15,
-              "marginTop": 0,
-              "minHeight": 37.714285714285715,
-              "paddingBottom": 0,
-              "paddingLeft": 0,
-              "paddingRight": 0,
-              "paddingTop": 0,
-              "width": "100%",
+              "lineHeight": 18,
+              "position": "absolute",
+              "top": 8,
             },
-            Object {},
+            Object {
+              "fontSize": 18,
+              "top": 8,
+            },
           ]
         }
-        testID="test"
-        textAlign="left"
-        type="no-mask"
-        underlineColorAndroid="transparent"
-        value=""
+        testID="error_test"
         variant="md"
-        withBottomline={true}
       />
       <View
-        collapsable={false}
-        nativeID="animatedComponent"
-        style={Object {}}
+        multiline={false}
+        rightIcon={true}
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
+              "maxWidth": "100%",
+              "overflow": "hidden",
+              "paddingLeft": 4,
+              "paddingRight": 4,
+              "paddingTop": 4,
+            },
+          ]
+        }
       >
-        <View
-          accessibilityLabel="icon_test"
-          accessibilityState={
-            Object {
-              "disabled": false,
-            }
-          }
-          accessible={true}
-          collapsable={false}
-          focusable={true}
-          hitSlop={
-            Object {
-              "bottom": 40,
-              "left": 40,
-              "right": 40,
-              "top": 40,
-            }
-          }
-          nativeID="animatedComponent"
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
+        <TextInput
+          accessibility="test"
+          accessibilityLabel="test"
+          allowFontScaling={false}
+          centered={false}
+          contrast={false}
+          id="test"
+          inputRef="$text"
+          isPlaceholder={true}
+          keyboardType="default"
+          large={false}
+          multiline={false}
+          onBlur={[Function]}
+          onChangeText={[Function]}
+          onFocus={[Function]}
+          placeholder=""
+          placeholderTextColor="#72727260"
+          secureTextEntry={true}
+          status="default"
           style={
-            Object {
-              "opacity": 1,
-            }
+            Array [
+              Object {
+                "borderWidth": 0,
+                "color": "#000000",
+                "flexBasis": 0,
+                "flexGrow": 1,
+                "flexShrink": 1,
+                "fontSize": 15,
+                "marginTop": 0,
+                "minHeight": 37.714285714285715,
+                "paddingBottom": 0,
+                "paddingLeft": 0,
+                "paddingRight": 0,
+                "paddingTop": 0,
+                "width": "100%",
+              },
+              Object {},
+            ]
           }
-          testID="id_eye"
+          testID="test"
+          textAlign="left"
+          type="no-mask"
+          underlineColorAndroid="transparent"
+          value=""
+          variant="md"
+          withBottomline={true}
+        />
+        <View
+          collapsable={false}
+          nativeID="animatedComponent"
+          style={Object {}}
         >
-          <View>
-            <Text
-              allowFontScaling={false}
-              style={
-                Array [
-                  Object {
-                    "color": "#C6B09E",
-                    "fontSize": 20,
-                  },
-                  undefined,
-                  Object {
-                    "fontFamily": "Material Design Icons",
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
-                  },
-                  Object {},
-                ]
+          <View
+            accessibilityLabel="icon_test"
+            accessibilityState={
+              Object {
+                "disabled": false,
               }
-            >
-              󰈈
-            </Text>
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            hitSlop={
+              Object {
+                "bottom": 40,
+                "left": 40,
+                "right": 40,
+                "top": 40,
+              }
+            }
+            nativeID="animatedComponent"
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Object {
+                "opacity": 1,
+              }
+            }
+            testID="id_eye"
+          >
+            <View>
+              <Text
+                allowFontScaling={false}
+                style={
+                  Array [
+                    Object {
+                      "color": "#C6B09E",
+                      "fontSize": 20,
+                    },
+                    undefined,
+                    Object {
+                      "fontFamily": "Material Design Icons",
+                      "fontStyle": "normal",
+                      "fontWeight": "normal",
+                    },
+                    Object {},
+                  ]
+                }
+              >
+                󰈈
+              </Text>
+            </View>
           </View>
         </View>
       </View>
+      <View
+        contrast={false}
+        status="default"
+        style={
+          Array [
+            Object {
+              "backgroundColor": "#000000",
+              "height": 0.5,
+            },
+          ]
+        }
+      />
     </View>
-    <View
-      contrast={false}
-      status="default"
-      style={
-        Array [
-          Object {
-            "backgroundColor": "#000000",
-            "height": 0.5,
-          },
-        ]
-      }
-    />
   </View>
 </View>
 `;

--- a/src/components/TextInput/__tests__/__snapshots__/TextInput.spec.tsx.snap
+++ b/src/components/TextInput/__tests__/__snapshots__/TextInput.spec.tsx.snap
@@ -2,133 +2,142 @@
 
 exports[`<TextInput /> should render textinput 1`] = `
 <View
-  multiline={false}
   style={
     Array [
-      Object {
-        "justifyContent": "flex-start",
-        "paddingTop": 0,
-        "position": "relative",
-      },
+      Object {},
       Object {},
     ]
   }
 >
   <View
-    borderedRadius={0}
-    error={false}
-    showBorderErrored={true}
+    multiline={false}
     style={
       Array [
         Object {
-          "borderColor": "black",
-          "borderStyle": "solid",
-          "borderWidth": 0,
+          "justifyContent": "flex-start",
+          "paddingTop": 0,
+          "position": "relative",
         },
+        Object {},
       ]
     }
   >
-    <Text
-      accessibilityLabel="Erro "
-      collapsable={false}
-      contrast={false}
-      nativeID="animatedComponent"
-      status="default"
-      style={
-        Array [
-          Object {
-            "color": "#000000",
-            "fontSize": 15,
-            "lineHeight": 18,
-            "position": "absolute",
-            "top": 8,
-          },
-          Object {
-            "fontSize": 18,
-            "top": 8,
-          },
-        ]
-      }
-      testID="error_test"
-      variant="md"
-    />
     <View
-      multiline={false}
-      rightIcon={false}
+      borderedRadius={0}
+      error={false}
+      showBorderErrored={true}
       style={
         Array [
           Object {
-            "alignItems": "center",
-            "flexDirection": "row",
-            "justifyContent": "center",
-            "maxWidth": "100%",
-            "overflow": "hidden",
-            "paddingLeft": 4,
-            "paddingRight": 4,
-            "paddingTop": 4,
+            "borderColor": "black",
+            "borderStyle": "solid",
+            "borderWidth": 0,
           },
         ]
       }
     >
-      <TextInput
-        accessibility=""
-        accessibilityLabel=""
-        allowFontScaling={false}
-        centered={false}
+      <Text
+        accessibilityLabel="Erro "
+        collapsable={false}
         contrast={false}
-        id="test"
-        inputRef="$text"
-        isPlaceholder={true}
-        keyboardType="default"
-        large={false}
-        multiline={false}
-        onBlur={[Function]}
-        onChangeText={[Function]}
-        onFocus={[Function]}
-        placeholder=""
-        placeholderTextColor="#72727260"
+        nativeID="animatedComponent"
         status="default"
         style={
           Array [
             Object {
-              "borderWidth": 0,
               "color": "#000000",
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "fontSize": 15,
-              "marginTop": 0,
-              "minHeight": 37.714285714285715,
-              "paddingBottom": 0,
-              "paddingLeft": 0,
-              "paddingRight": 0,
-              "paddingTop": 0,
-              "width": "100%",
+              "lineHeight": 18,
+              "position": "absolute",
+              "top": 8,
             },
-            Object {},
+            Object {
+              "fontSize": 18,
+              "top": 8,
+            },
           ]
         }
-        testID="test"
-        textAlign="left"
-        type="no-mask"
-        underlineColorAndroid="transparent"
-        value=""
+        testID="error_test"
         variant="md"
-        withBottomline={true}
+      />
+      <View
+        multiline={false}
+        rightIcon={false}
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
+              "maxWidth": "100%",
+              "overflow": "hidden",
+              "paddingLeft": 4,
+              "paddingRight": 4,
+              "paddingTop": 4,
+            },
+          ]
+        }
+      >
+        <TextInput
+          accessibility=""
+          accessibilityLabel=""
+          allowFontScaling={false}
+          centered={false}
+          contrast={false}
+          id="test"
+          inputRef="$text"
+          isPlaceholder={true}
+          keyboardType="default"
+          large={false}
+          multiline={false}
+          onBlur={[Function]}
+          onChangeText={[Function]}
+          onFocus={[Function]}
+          placeholder=""
+          placeholderTextColor="#72727260"
+          status="default"
+          style={
+            Array [
+              Object {
+                "borderWidth": 0,
+                "color": "#000000",
+                "flexBasis": 0,
+                "flexGrow": 1,
+                "flexShrink": 1,
+                "fontSize": 15,
+                "marginTop": 0,
+                "minHeight": 37.714285714285715,
+                "paddingBottom": 0,
+                "paddingLeft": 0,
+                "paddingRight": 0,
+                "paddingTop": 0,
+                "width": "100%",
+              },
+              Object {},
+            ]
+          }
+          testID="test"
+          textAlign="left"
+          type="no-mask"
+          underlineColorAndroid="transparent"
+          value=""
+          variant="md"
+          withBottomline={true}
+        />
+      </View>
+      <View
+        contrast={false}
+        status="default"
+        style={
+          Array [
+            Object {
+              "backgroundColor": "#000000",
+              "height": 0.5,
+            },
+          ]
+        }
       />
     </View>
-    <View
-      contrast={false}
-      status="default"
-      style={
-        Array [
-          Object {
-            "backgroundColor": "#000000",
-            "height": 0.5,
-          },
-        ]
-      }
-    />
   </View>
 </View>
 `;

--- a/src/components/TextInput/index.tsx
+++ b/src/components/TextInput/index.tsx
@@ -17,10 +17,11 @@ import {
   InputAreaWrapper,
   InputBorderedAreaWrapper,
   InputBorderedColumnWrapper,
+  InputWrapper,
   LABEL_LOWER_STYLE,
   LABEL_UPPER_STYLE,
   Label,
-  Wrapper,
+  RootWrapper,
 } from './styles';
 
 const TextInput: VFC<TextInputType> = ({
@@ -47,7 +48,9 @@ const TextInput: VFC<TextInputType> = ({
   placeholder = '',
   error = '',
   style = {},
+  errorStyle = {},
   textStyle = {},
+  rootStyle = {},
   labelStyle = {},
   iconHitSlop = {},
   inputRef,
@@ -228,86 +231,91 @@ const TextInput: VFC<TextInputType> = ({
   );
 
   return (
-    <Wrapper style={style} multiline={multiline}>
+    <RootWrapper style={rootStyle}>
       <FormError
         id={id || accessibility}
         accessibility={accessibility}
         centered={centered}
         error={error}
         large={large}
+        style={errorStyle}
       >
-        <BorderedWrapper
-          borderedBackgroundColor={borderedBackgroundColor}
-          borderedHeight={borderedHeight}
-          borderedColor={borderedColor}
-          borderedRadius={borderedRadius}
-          error={hasError}
-          showBorderErrored={showBorderErrored}
-        >
-          {!centered &&
-            !borderedHeight &&
-            !(hidePlaceholderOnFocus && !isPlaceholder) && (
-              <Label
-                status={status}
-                contrast={contrast}
-                style={[labelAnimatedStyle, labelStyle]}
-                variant={isPlaceholder ? placeholderVariant : labelVariant}
-                testID={`error_${id || accessibility}`}
-                accessibilityLabel={`Erro ${accessibility}`}
+        <InputWrapper style={style} multiline={multiline}>
+          <BorderedWrapper
+            borderedBackgroundColor={borderedBackgroundColor}
+            borderedHeight={borderedHeight}
+            borderedColor={borderedColor}
+            borderedRadius={borderedRadius}
+            error={hasError}
+            showBorderErrored={showBorderErrored}
+          >
+            {!centered &&
+              !borderedHeight &&
+              !(hidePlaceholderOnFocus && !isPlaceholder) && (
+                <Label
+                  status={status}
+                  contrast={contrast}
+                  style={[labelAnimatedStyle, labelStyle]}
+                  variant={isPlaceholder ? placeholderVariant : labelVariant}
+                  testID={`error_${id || accessibility}`}
+                  accessibilityLabel={`Erro ${accessibility}`}
+                >
+                  {label}
+                </Label>
+              )}
+            {!isEmpty(borderedLabel) && isEmpty(label) && !!borderedHeight && (
+              <FixedLabelAboveBorder
+                style={labelStyle}
+                variant={fixedLabelVariant}
               >
-                {label}
-              </Label>
+                {borderedLabel}
+              </FixedLabelAboveBorder>
             )}
-          {!isEmpty(borderedLabel) && isEmpty(label) && !!borderedHeight && (
-            <FixedLabelAboveBorder
-              style={labelStyle}
-              variant={fixedLabelVariant}
-            >
-              {borderedLabel}
-            </FixedLabelAboveBorder>
-          )}
-          {borderedHeight ? (
-            <InputBorderedAreaWrapper hasBottomLine={withBottomline}>
-              {!isEmpty(iconBordered) && renderIcon(iconBordered, true)}
-              <InputBorderedColumnWrapper
-                hasLeftIcon={!isEmpty(iconBordered)}
+            {borderedHeight ? (
+              <InputBorderedAreaWrapper hasBottomLine={withBottomline}>
+                {!isEmpty(iconBordered) && renderIcon(iconBordered, true)}
+                <InputBorderedColumnWrapper
+                  hasLeftIcon={!isEmpty(iconBordered)}
+                  multiline={multiline}
+                  padding={inputPadding}
+                >
+                  {!isEmpty(label) && isEmpty(borderedLabel) && (
+                    <FixedLabel
+                      hasLeftIcon={!isEmpty(iconBordered)}
+                      variant={fixedLabelVariant}
+                    >
+                      {label}
+                    </FixedLabel>
+                  )}
+                  {renderTextInput(renderStatus)}
+                </InputBorderedColumnWrapper>
+                {!isEmpty(icon) && renderIcon(icon || '')}
+              </InputBorderedAreaWrapper>
+            ) : (
+              <InputAreaWrapper
                 multiline={multiline}
                 padding={inputPadding}
+                rightIcon={!!rightIconName}
+                inputLeftPadding={inputLeftPadding}
+                inputRightPadding={inputRightPadding}
               >
-                {!isEmpty(label) && isEmpty(borderedLabel) && (
-                  <FixedLabel
-                    hasLeftIcon={!isEmpty(iconBordered)}
-                    variant={fixedLabelVariant}
-                  >
-                    {label}
-                  </FixedLabel>
-                )}
+                {borderedHeight && <FixedLabel>{label}</FixedLabel>}
+                {!!leftIconName && renderIcon(leftIconName, true)}
                 {renderTextInput(renderStatus)}
-              </InputBorderedColumnWrapper>
-              {!isEmpty(icon) && renderIcon(icon || '')}
-            </InputBorderedAreaWrapper>
-          ) : (
-            <InputAreaWrapper
-              multiline={multiline}
-              padding={inputPadding}
-              rightIcon={!!rightIconName}
-              inputLeftPadding={inputLeftPadding}
-              inputRightPadding={inputRightPadding}
-            >
-              {borderedHeight && <FixedLabel>{label}</FixedLabel>}
-              {!!leftIconName && renderIcon(leftIconName, true)}
-              {renderTextInput(renderStatus)}
-              {!!rightIconName && renderIcon(rightIconName)}
-              {!leftIconName &&
-                !rightIconName &&
-                !isEmpty(icon) &&
-                renderIcon(icon as string)}
-            </InputAreaWrapper>
-          )}
-          {withBottomline && <BottomLine status={status} contrast={contrast} />}
-        </BorderedWrapper>
+                {!!rightIconName && renderIcon(rightIconName)}
+                {!leftIconName &&
+                  !rightIconName &&
+                  !isEmpty(icon) &&
+                  renderIcon(icon as string)}
+              </InputAreaWrapper>
+            )}
+            {withBottomline && (
+              <BottomLine status={status} contrast={contrast} />
+            )}
+          </BorderedWrapper>
+        </InputWrapper>
       </FormError>
-    </Wrapper>
+    </RootWrapper>
   );
 };
 

--- a/src/components/TextInput/styles.ts
+++ b/src/components/TextInput/styles.ts
@@ -105,7 +105,11 @@ type WrapperProps = {
   style?: any;
 };
 
-export const RootWrapper = styled.View<any>``;
+type RootWrapperProps = {
+  style?: any;
+};
+
+export const RootWrapper = styled.View<RootWrapperProps>``;
 
 export const InputWrapper = styled.View<WrapperProps>`
   justify-content: ${hasLabel('flex-end', 'flex-start')};

--- a/src/components/TextInput/styles.ts
+++ b/src/components/TextInput/styles.ts
@@ -105,7 +105,9 @@ type WrapperProps = {
   style?: any;
 };
 
-export const Wrapper = styled.View<WrapperProps>`
+export const RootWrapper = styled.View<any>``;
+
+export const InputWrapper = styled.View<WrapperProps>`
   justify-content: ${hasLabel('flex-end', 'flex-start')};
   padding-top: ${hasLabel(smallSpacing, 0)}px;
   position: relative;

--- a/src/types/TextInputType.ts
+++ b/src/types/TextInputType.ts
@@ -29,8 +29,8 @@ export type TextInputType = {
   iconTouchableEnabled?: boolean;
   textStyle?: StyleProp<TextStyle>;
   labelStyle?: any;
-  rootStyle?: StyleProp<ViewStyle>;
-  errorStyle?: StyleProp<TextStyle>;
+  rootStyle?: any;
+  errorStyle?: any;
   maskType?: TextInputMaskTypeProp;
   label?: string;
   iconName?: string;

--- a/src/types/TextInputType.ts
+++ b/src/types/TextInputType.ts
@@ -29,8 +29,8 @@ export type TextInputType = {
   iconTouchableEnabled?: boolean;
   textStyle?: StyleProp<TextStyle>;
   labelStyle?: any;
-  rootStyle?: any;
-  errorStyle?: any;
+  rootStyle?: StyleProp<ViewStyle>;
+  errorStyle?: StyleProp<TextStyle>;
   maskType?: TextInputMaskTypeProp;
   label?: string;
   iconName?: string;

--- a/src/types/TextInputType.ts
+++ b/src/types/TextInputType.ts
@@ -28,13 +28,15 @@ export type TextInputType = {
   iconSize?: number;
   iconTouchableEnabled?: boolean;
   textStyle?: StyleProp<TextStyle>;
+  labelStyle?: any;
+  rootStyle?: StyleProp<ViewStyle>;
+  errorStyle?: StyleProp<TextStyle>;
   maskType?: TextInputMaskTypeProp;
   label?: string;
   iconName?: string;
   status?: string;
   error?: string | boolean;
   iconHitSlop?: HitSlopType;
-  labelStyle?: any;
   isPlaceholder?: boolean;
   onPressIcon?(arg?: any): void;
   onBlur?(x?: any): void;

--- a/src/types/TouchableType.ts
+++ b/src/types/TouchableType.ts
@@ -1,6 +1,7 @@
 import { HapticFeedbackType } from 'react-native-haptic';
 
 export interface TouchableType {
+  children?: any;
   id?: string;
   accessibility: string;
   accessibilityLabel?: string;

--- a/src/types/TouchableType.ts
+++ b/src/types/TouchableType.ts
@@ -1,7 +1,7 @@
 import { HapticFeedbackType } from 'react-native-haptic';
 
 export interface TouchableType {
-  children?: any;
+  children?: React.ReactNode;
   id?: string;
   accessibility: string;
   accessibilityLabel?: string;


### PR DESCRIPTION
## O que foi feito? 📝

- Adicionado `RootWrapper` para que customização do component `TextInput` não afete o `FormError`
- Adicionado `rootStyle` e `errorStyle` para styling que precise afetar apenas o `FormError` ou o wrapper de todo input

## Screenshots ou GIFs 📸

<!-- dica: use o KAP ou tire um print com cmd + shift + 5 -->

<img width="376" alt="image" src="https://user-images.githubusercontent.com/6873880/196052778-7864037b-e4be-40b4-af1a-bd9a55dcaf3d.png">
<img width="425" alt="image" src="https://user-images.githubusercontent.com/6873880/196052802-3060f978-c482-40bc-9dde-241fa2230511.png">


## Tipo de mudança 🏗

- [X] Nova feature (mudança non-breaking que adiciona uma funcionalidade)
- [ ] Bug fix (mudança non-breaking que conserta um problema)
- [ ] Refactor (mudança non-breaking que melhora o código ou débito técnico)
- [ ] Chore (nenhuma das anteriores, como upgrade de libs)
- [ ] Breaking change 🚨

## Checklist 🧐

<!-- mobile -->

- [X] Testado no iOS
- [X] Testado no Android
