### PR TITLE
Adding button to clear uploaded image in `UploadPhoto`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformbuilders/fluid-react-native",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": false,
   "description": "Builders React Native for Fluid Design System",
   "keywords": [

--- a/src/components/UploadPhoto/index.tsx
+++ b/src/components/UploadPhoto/index.tsx
@@ -1,4 +1,4 @@
-import React, { useImperativeHandle, useRef, useState } from 'react';
+import React, { useEffect, useImperativeHandle, useRef, useState } from 'react';
 import { RNCamera } from 'react-native-camera';
 import FastImage, { Source } from 'react-native-fast-image';
 import {
@@ -8,6 +8,8 @@ import {
 import { IconFonts, UploadPhotoType } from '../../types';
 import {
   CameraView,
+  DeleteIcon,
+  DeleteIconWrapper,
   UploadIcon,
   UploadIconWrapper,
   UploadText,
@@ -24,18 +26,26 @@ const UploadPhoto: React.FC<UploadPhotoType> = React.forwardRef(
       testID,
       uploadText = 'Adicionar Foto',
       uploadIcon = 'image',
+      deleteIcon = 'image',
       imageQuality = 0.5,
-      iconSize = 36,
+      uploadIconSize = 36,
       onPress,
       onUpload,
+      onClearUpload,
       displayCamera = false,
       iconType = IconFonts.Material,
       ...rest
     },
     ref,
   ) => {
-    const [uploadedImage, setUploadedImage] = useState<any>(image);
+    const [uploadedImage, setUploadedImage] = useState<any>('');
     const cameraRef = useRef<any>();
+
+    useEffect(() => {
+      if (image) {
+        setUploadedImage(image);
+      }
+    }, [image]);
 
     const openPicker = (): Promise<void> => {
       const options = {
@@ -78,6 +88,13 @@ const UploadPhoto: React.FC<UploadPhotoType> = React.forwardRef(
 
     const clearUploadImage = (): void => {
       setUploadedImage('');
+    };
+
+    const clearUpload = (): void => {
+      setUploadedImage('');
+      if (onClearUpload) {
+        onClearUpload();
+      }
     };
 
     const getCurrentPhoto = (): Source | any => {
@@ -128,7 +145,7 @@ const UploadPhoto: React.FC<UploadPhotoType> = React.forwardRef(
           <UploadIconWrapper>
             <UploadIcon
               disabled
-              size={iconSize}
+              size={uploadIconSize}
               name={uploadIcon}
               id=""
               accessibility=""
@@ -136,6 +153,20 @@ const UploadPhoto: React.FC<UploadPhotoType> = React.forwardRef(
             />
             {uploadText && <UploadText>{uploadText}</UploadText>}
           </UploadIconWrapper>
+        )}
+        {uploadedImage && (
+          <DeleteIconWrapper
+            accessibility="Remover imagem"
+            onPress={clearUpload}
+          >
+            <DeleteIcon
+              disabled
+              name={deleteIcon}
+              id="remove_image_button"
+              accessibility=""
+              type={iconType}
+            />
+          </DeleteIconWrapper>
         )}
       </Wrapper>
     );

--- a/src/components/UploadPhoto/styles.ts
+++ b/src/components/UploadPhoto/styles.ts
@@ -6,10 +6,12 @@ import Touchable from '../Touchable';
 import Typography from '../Typography';
 
 const iconColor = getTheme('text.main');
+const deleteIconColor = getTheme('text.main');
 const brandPrimaryMain = getTheme('brand.primary.main');
 const backgroundZ2 = getTheme('background.z2');
 const borderRadius = getTheme('themeRadius.card');
 const spacingMd = getTheme('spacing.md');
+const spacingSm = getTheme('spacing.sm');
 
 type WrapperProps = {
   disabled: boolean;
@@ -38,6 +40,25 @@ export const UploadIcon = styled(Icon).attrs((props) => ({
   margin-bottom: ${spacingMd}px;
   opacity: 0.6;
 `;
+
+export const DeleteIconWrapper = styled(Touchable)`
+  position: absolute;
+  top: ${spacingSm}px;
+  right: ${spacingSm}px;
+  z-index: 1;
+  height: 24px;
+  width: 24px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50px;
+  background-color: ${backgroundZ2};
+  opacity: 0.6;
+`;
+
+export const DeleteIcon = styled(Icon).attrs((props) => ({
+  color: deleteIconColor(props),
+  size: 10,
+}))``;
 
 export const CameraView = styled(RNCamera)`
   height: 100%;

--- a/src/types/UploadPhoto.ts
+++ b/src/types/UploadPhoto.ts
@@ -6,12 +6,14 @@ export type UploadPhotoType = {
   displayCamera?: boolean;
   onPress?: (x: any) => void;
   onUpload?: (x: any) => any;
+  onClearUpload?: () => any;
   id?: string;
   accessibility: string;
   accessibilityLabel?: string;
   uploadText?: string;
-  iconSize?: number;
+  uploadIconSize?: number;
   uploadIcon?: string;
+  deleteIcon?: string;
   testID?: string;
   iconType?: IconFonts;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1689,7 +1689,7 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@fnando/cpf@^1.0.2":
+"@fnando/cpf@1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@fnando/cpf/-/cpf-1.0.2.tgz#e78c46c5ee599b17f5d81b46c336b0e6eec8ace4"
   integrity sha512-lfSfdONVQ/1aKvsA7PnawQjSoE5PXOyHich3WFIbAuYRMAw6Ax1FmIWxPxCfHP/Rh0R2cG/CxaimUW7NI6rgEQ==
@@ -15207,7 +15207,7 @@ react-native-markdown-display@7.0.0-alpha.2:
     prop-types "^15.7.2"
     react-native-fit-image "^1.5.5"
 
-react-native-masked-input@^2.2.3:
+react-native-masked-input@2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/react-native-masked-input/-/react-native-masked-input-2.2.3.tgz#a21ec2df5b584b0f4bf8cfb5ccf3f75272c77985"
   integrity sha512-1BEMtMp1VIQKCAkDnuoOBKmU7jfSjchCJlGIc8x+3cvO5eRLM0uutQ6wBD4jTWNiJc7nle56V6MDI/nVguOOzA==


### PR DESCRIPTION
## O que foi feito? 📝

- Adicionado botão para limpar foto do component `UploadPhoto` 

## Screenshots ou GIFs 📸

![image](https://github.com/platformbuilders/fluid-react-native/assets/6873880/411c46a5-de11-4a4d-88a0-1e208e2c6ba8)

## Tipo de mudança 🏗

- [X] Nova feature (mudança non-breaking que adiciona uma funcionalidade)
- [ ] Bug fix (mudança non-breaking que conserta um problema)
- [ ] Refactor (mudança non-breaking que melhora o código ou débito técnico)
- [ ] Chore (nenhuma das anteriores, como upgrade de libs)
- [ ] Breaking change 🚨

## Checklist 🧐

<!-- mobile -->

- [X] Testado no iOS
- [ ] Testado no Android
