### PR TITLE
Feat/disable touchable icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformbuilders/fluid-react-native",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "private": false,
   "description": "Builders React Native for Fluid Design System",
   "keywords": [

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -24,6 +24,8 @@ const Button: FC<ButtonProps> = ({
   maxWidth,
   rightIconName,
   leftIconName,
+  leftIconTouchable = true,
+  rightIconTouchable = true,
 }) => {
   return (
     <Touchable
@@ -58,6 +60,7 @@ const Button: FC<ButtonProps> = ({
                 buttonVariant={variant}
                 colorVariant={colorVariant}
                 style={style}
+                touchable={leftIconTouchable}
                 leftIcon
               />
             </If>
@@ -78,6 +81,7 @@ const Button: FC<ButtonProps> = ({
                 colorVariant={colorVariant}
                 buttonVariant={variant}
                 style={style}
+                touchable={rightIconTouchable}
                 rightIcon
               />
             </If>

--- a/src/types/Button.ts
+++ b/src/types/Button.ts
@@ -23,5 +23,7 @@ export type ButtonProps = PropsWithChildren<
     maxWidth?: string | number;
     leftIconName?: string;
     rightIconName?: string;
+    leftIconTouchable?: boolean;
+    rightIconTouchable?: boolean;
   } & TouchableType
 >;


### PR DESCRIPTION
## O que foi feito? 📝

Habilitado `rightIconTouchable` e `leftIconTouchable` para permitir desabilitar o touchable de icones 


## Tipo de mudança 🏗

- [x] Nova feature (mudança non-breaking que adiciona uma funcionalidade)
- [ ] Bug fix (mudança non-breaking que conserta um problema)
- [ ] Refactor (mudança non-breaking que melhora o código ou débito técnico)
- [ ] Chore (nenhuma das anteriores, como upgrade de libs)
- [ ] Breaking change 🚨

## Checklist 🧐

<!-- mobile -->

- [ ] Testado no iOS
- [x] Testado no Android
